### PR TITLE
Exclude text selection test for preview command in valid editor check

### DIFF
--- a/authoring-extension/src/controllers/preview-controller.ts
+++ b/authoring-extension/src/controllers/preview-controller.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 import * as common from "../helper/common";
 import { reporter } from "../telemetry/telemetry";
 
-const telemetryCommand: string = "preview topic";
+const telemetryCommand: string = "previewTopic";
 
 export function previewTopicCommand() {
     const commands = [
@@ -18,7 +18,7 @@ export function previewTopic() {
 
     const editor = vscode.window.activeTextEditor;
 
-    if (!common.isValidEditor(editor, true, "previewTopic")) {
+    if (!common.isValidEditor(editor, false, "preview topic")) {
         return;
     }
 

--- a/authoring-extension/src/helper/common.ts
+++ b/authoring-extension/src/helper/common.ts
@@ -99,7 +99,7 @@ export function isValidEditor(editor: vscode.TextEditor, testSelection: boolean,
     }
 
     if (testSelection && editor.selection.isEmpty) {
-        if (senderName === "format bold" || senderName === "format italic" || senderName === "format code" || senderName !== "preview topic") {
+        if (senderName === "format bold" || senderName === "format italic" || senderName === "format code") {
             log.debug("VS Code active editor has valid configuration to apply " + senderName + " to.");
             return true;
         }


### PR DESCRIPTION
Add a condition to ignore empty editor check for preview command.