### PR TITLE
Update keybinding for MacOS

### DIFF
--- a/authoring-extension/package.json
+++ b/authoring-extension/package.json
@@ -69,7 +69,7 @@
       {
         "command": "automaticList",
         "key": "enter",
-        "mac": "return",
+        "mac": "enter",
         "when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible"
       },
       {


### PR DESCRIPTION
"Return" is not working for lists on MacOS.  In addition, AutomaticList keybinding is not preserved using "return" but works fine using "enter".