### PR TITLE
build: Add typings for node-dir

### DIFF
--- a/authoring-extension/package-lock.json
+++ b/authoring-extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-markdown",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -22,7 +22,7 @@
       "integrity": "sha512-bOCCutkbehfCeiSqJO5XcVKjsJvX28dgvjhs4aMmBAHAsOy2oOJQwHuIZ0elI1E94qQIdEsCvz8oLgUumd6teA==",
       "dev": true,
       "requires": {
-        "@types/lodash": "*"
+        "@types/lodash": "4.14.104"
       }
     },
     "@types/mocha": {
@@ -37,6 +37,15 @@
       "integrity": "sha512-X4MNN+Z36OmVPv7n08wxq46/t61/rauW4+xeyxGPueDQ9t7SetHnuEPS0p9n6wU/15HvJLGjzfLTc/RwN7id3A==",
       "dev": true
     },
+    "@types/node-dir": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/@types/node-dir/-/node-dir-0.0.32.tgz",
+      "integrity": "sha512-M0++KmfiQ3DkSwx4O7glGut17ORbb+wuSfxLafMakAv8wmhAazTKb7ghfwYoqhRRErZ2quYQBYIppj5TPGaKVw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "7.0.61"
+      }
+    },
     "@types/yamljs": {
       "version": "0.2.30",
       "resolved": "https://registry.npmjs.org/@types/yamljs/-/yamljs-0.2.30.tgz",
@@ -49,10 +58,10 @@
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ansi-cyan": {
@@ -110,7 +119,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -119,8 +128,8 @@
       "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1",
-        "array-slice": "^0.2.3"
+        "arr-flatten": "1.1.0",
+        "array-slice": "0.2.3"
       }
     },
     "arr-flatten": {
@@ -153,7 +162,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -216,9 +225,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "chalk": {
@@ -227,11 +236,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "supports-color": {
@@ -254,7 +263,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "beeper": {
@@ -269,7 +278,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.0"
+        "inherits": "2.0.3"
       }
     },
     "boom": {
@@ -278,7 +287,7 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "2.16.3"
       }
     },
     "brace-expansion": {
@@ -286,7 +295,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -296,9 +305,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "browser-stdout": {
@@ -337,9 +346,9 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "assertion-error": "1.1.0",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
       }
     },
     "chalk": {
@@ -348,9 +357,9 @@
       "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.2.0"
+        "ansi-styles": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -359,7 +368,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "supports-color": {
@@ -368,7 +377,7 @@
           "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -397,9 +406,9 @@
       "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "co": {
@@ -414,7 +423,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -435,7 +444,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -467,7 +476,7 @@
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "2.x.x"
+        "boom": "2.10.1"
       }
     },
     "dashdash": {
@@ -476,7 +485,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -508,7 +517,7 @@
       "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "deep-eql": {
@@ -552,7 +561,7 @@
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.1.9"
+        "readable-stream": "1.1.14"
       },
       "dependencies": {
         "isarray": {
@@ -567,10 +576,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -587,10 +596,10 @@
       "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -600,7 +609,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "end-of-stream": {
@@ -609,7 +618,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "escape-string-regexp": {
@@ -635,13 +644,13 @@
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
         "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
       }
     },
     "expand-brackets": {
@@ -650,7 +659,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -659,7 +668,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.3"
       }
     },
     "extend": {
@@ -674,7 +683,7 @@
       "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
       "dev": true,
       "requires": {
-        "kind-of": "^1.1.0"
+        "kind-of": "1.1.0"
       }
     },
     "extglob": {
@@ -683,7 +692,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -706,9 +715,9 @@
       "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "ansi-gray": "^0.1.1",
-        "color-support": "^1.1.3",
-        "time-stamp": "^1.0.0"
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -729,7 +738,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "file-exists": {
@@ -749,11 +758,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "first-chunk-stream": {
@@ -774,7 +783,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "forever-agent": {
@@ -789,9 +798,9 @@
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.5",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
       }
     },
     "from": {
@@ -816,10 +825,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
       }
     },
     "generate-function": {
@@ -834,7 +843,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "getpass": {
@@ -843,7 +852,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -859,12 +868,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -873,8 +882,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "glob-parent": {
@@ -883,7 +892,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "^2.0.0"
+            "is-glob": "2.0.1"
           }
         },
         "is-extglob": {
@@ -898,7 +907,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -909,8 +918,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
+        "is-glob": "3.1.0",
+        "path-dirname": "1.0.2"
       }
     },
     "glob-stream": {
@@ -919,14 +928,14 @@
       "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
       "dev": true,
       "requires": {
-        "extend": "^3.0.0",
-        "glob": "^5.0.3",
-        "glob-parent": "^3.0.0",
-        "micromatch": "^2.3.7",
-        "ordered-read-streams": "^0.3.0",
-        "through2": "^0.6.0",
-        "to-absolute-glob": "^0.1.1",
-        "unique-stream": "^2.0.2"
+        "extend": "3.0.1",
+        "glob": "5.0.15",
+        "glob-parent": "3.1.0",
+        "micromatch": "2.3.11",
+        "ordered-read-streams": "0.3.0",
+        "through2": "0.6.5",
+        "to-absolute-glob": "0.1.1",
+        "unique-stream": "2.2.1"
       },
       "dependencies": {
         "glob": {
@@ -935,11 +944,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "isarray": {
@@ -954,10 +963,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -972,8 +981,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -984,7 +993,7 @@
       "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "graceful-fs": {
@@ -1005,9 +1014,9 @@
       "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
       "dev": true,
       "requires": {
-        "deep-assign": "^1.0.0",
-        "stat-mode": "^0.2.0",
-        "through2": "^2.0.0"
+        "deep-assign": "1.0.0",
+        "stat-mode": "0.2.2",
+        "through2": "2.0.3"
       }
     },
     "gulp-filter": {
@@ -1016,9 +1025,9 @@
       "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
       "dev": true,
       "requires": {
-        "multimatch": "^2.0.0",
-        "plugin-error": "^0.1.2",
-        "streamfilter": "^1.0.5"
+        "multimatch": "2.1.0",
+        "plugin-error": "0.1.2",
+        "streamfilter": "1.0.7"
       }
     },
     "gulp-gunzip": {
@@ -1027,8 +1036,8 @@
       "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
       "dev": true,
       "requires": {
-        "through2": "~0.6.5",
-        "vinyl": "~0.4.6"
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
       },
       "dependencies": {
         "isarray": {
@@ -1043,10 +1052,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -1061,8 +1070,8 @@
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -1073,11 +1082,11 @@
       "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
       "dev": true,
       "requires": {
-        "event-stream": "~3.3.4",
-        "node.extend": "~1.1.2",
-        "request": "~2.79.0",
-        "through2": "~2.0.3",
-        "vinyl": "~2.0.1"
+        "event-stream": "3.3.4",
+        "node.extend": "1.1.6",
+        "request": "2.79.0",
+        "through2": "2.0.3",
+        "vinyl": "2.0.2"
       },
       "dependencies": {
         "clone": {
@@ -1098,26 +1107,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.11.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~2.0.6",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "qs": "~6.3.0",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "~0.4.1",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.11.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "2.0.6",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "qs": "6.3.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.4.3",
+            "uuid": "3.2.1"
           }
         },
         "vinyl": {
@@ -1126,13 +1135,13 @@
           "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "is-stream": "^1.1.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "1.0.4",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "is-stream": "1.1.0",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -1143,11 +1152,11 @@
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
       "requires": {
-        "convert-source-map": "^1.1.1",
-        "graceful-fs": "^4.1.2",
-        "strip-bom": "^2.0.0",
-        "through2": "^2.0.0",
-        "vinyl": "^1.0.0"
+        "convert-source-map": "1.5.1",
+        "graceful-fs": "4.1.11",
+        "strip-bom": "2.0.0",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "clone": {
@@ -1168,8 +1177,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -1181,10 +1190,10 @@
       "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
       "dev": true,
       "requires": {
-        "event-stream": "^3.3.1",
-        "mkdirp": "^0.5.1",
-        "queue": "^3.1.0",
-        "vinyl-fs": "^2.4.3"
+        "event-stream": "3.3.4",
+        "mkdirp": "0.5.1",
+        "queue": "3.1.0",
+        "vinyl-fs": "2.4.4"
       }
     },
     "gulp-untar": {
@@ -1193,11 +1202,11 @@
       "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
       "dev": true,
       "requires": {
-        "event-stream": "~3.3.4",
-        "gulp-util": "~3.0.8",
-        "streamifier": "~0.1.1",
-        "tar": "^2.2.1",
-        "through2": "~2.0.3"
+        "event-stream": "3.3.4",
+        "gulp-util": "3.0.8",
+        "streamifier": "0.1.1",
+        "tar": "2.2.1",
+        "through2": "2.0.3"
       }
     },
     "gulp-util": {
@@ -1206,24 +1215,24 @@
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-uniq": "^1.0.2",
-        "beeper": "^1.0.0",
-        "chalk": "^1.0.0",
-        "dateformat": "^2.0.0",
-        "fancy-log": "^1.1.0",
-        "gulplog": "^1.0.0",
-        "has-gulplog": "^0.1.0",
-        "lodash._reescape": "^3.0.0",
-        "lodash._reevaluate": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.template": "^3.0.0",
-        "minimist": "^1.1.0",
-        "multipipe": "^0.1.2",
-        "object-assign": "^3.0.0",
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
         "replace-ext": "0.0.1",
-        "through2": "^2.0.0",
-        "vinyl": "^0.5.0"
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
       },
       "dependencies": {
         "chalk": {
@@ -1232,11 +1241,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "clone": {
@@ -1275,8 +1284,8 @@
           "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -1288,13 +1297,13 @@
       "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
       "dev": true,
       "requires": {
-        "event-stream": "^3.3.1",
-        "queue": "^4.2.1",
-        "through2": "^2.0.3",
-        "vinyl": "^2.0.2",
-        "vinyl-fs": "^2.0.0",
-        "yauzl": "^2.2.1",
-        "yazl": "^2.2.1"
+        "event-stream": "3.3.4",
+        "queue": "4.4.2",
+        "through2": "2.0.3",
+        "vinyl": "2.1.0",
+        "vinyl-fs": "2.4.4",
+        "yauzl": "2.9.1",
+        "yazl": "2.4.3"
       },
       "dependencies": {
         "clone": {
@@ -1315,7 +1324,7 @@
           "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
           "dev": true,
           "requires": {
-            "inherits": "~2.0.0"
+            "inherits": "2.0.3"
           }
         },
         "vinyl": {
@@ -1324,12 +1333,12 @@
           "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.2",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.0"
           }
         }
       }
@@ -1340,7 +1349,7 @@
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
       "dev": true,
       "requires": {
-        "glogg": "^1.0.0"
+        "glogg": "1.0.1"
       }
     },
     "har-schema": {
@@ -1355,10 +1364,10 @@
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.1",
-        "commander": "^2.9.0",
-        "is-my-json-valid": "^2.12.4",
-        "pinkie-promise": "^2.0.0"
+        "chalk": "1.1.3",
+        "commander": "2.15.1",
+        "is-my-json-valid": "2.17.2",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "chalk": {
@@ -1367,11 +1376,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "commander": {
@@ -1394,7 +1403,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -1409,7 +1418,7 @@
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
       "dev": true,
       "requires": {
-        "sparkles": "^1.0.0"
+        "sparkles": "1.0.0"
       }
     },
     "hawk": {
@@ -1418,10 +1427,10 @@
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
       }
     },
     "he": {
@@ -1442,9 +1451,9 @@
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
-        "assert-plus": "^0.2.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
       }
     },
     "inflight": {
@@ -1452,8 +1461,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -1485,7 +1494,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -1506,7 +1515,7 @@
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.0"
+        "is-extglob": "2.1.1"
       }
     },
     "is-my-ip-valid": {
@@ -1521,11 +1530,11 @@
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "is-my-ip-valid": "^1.0.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-number": {
@@ -1534,7 +1543,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -1543,7 +1552,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -1653,8 +1662,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.0"
       }
     },
     "jsbn": {
@@ -1682,7 +1691,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -1735,7 +1744,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.5"
+        "readable-stream": "2.3.6"
       }
     },
     "lodash._basecopy": {
@@ -1798,7 +1807,7 @@
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
       "dev": true,
       "requires": {
-        "lodash._root": "^3.0.0"
+        "lodash._root": "3.0.1"
       }
     },
     "lodash.isarguments": {
@@ -1825,9 +1834,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
       }
     },
     "lodash.merge": {
@@ -1847,15 +1856,15 @@
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
       }
     },
     "lodash.templatesettings": {
@@ -1864,8 +1873,8 @@
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0"
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
       }
     },
     "lru-cache": {
@@ -1885,7 +1894,7 @@
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.1.0.tgz",
       "integrity": "sha512-aZGv6JBTHqfqAd09jmAlbKnAICTfIvb5Z8gXVxPB5WZtFfHMaAMdACL7tQflD2V+6/8KNcY8s6DYtWLgpJP5lA==",
       "requires": {
-        "escape-string-regexp": "^1.0.4"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "merge-stream": {
@@ -1894,7 +1903,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "micromatch": {
@@ -1903,19 +1912,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       },
       "dependencies": {
         "arr-diff": {
@@ -1924,7 +1933,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "is-extglob": {
@@ -1939,7 +1948,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "kind-of": {
@@ -1948,7 +1957,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -1965,7 +1974,7 @@
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "minimatch": {
@@ -1973,7 +1982,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -2021,8 +2030,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2",
-            "minimatch": "0.3"
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
           }
         },
         "minimatch": {
@@ -2031,8 +2040,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
           }
         }
       }
@@ -2049,10 +2058,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
       }
     },
     "multipipe": {
@@ -2069,7 +2078,7 @@
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
       "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
       "requires": {
-        "minimatch": "^3.0.2"
+        "minimatch": "3.0.4"
       }
     },
     "node.extend": {
@@ -2078,7 +2087,7 @@
       "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
       "dev": true,
       "requires": {
-        "is": "^3.1.0"
+        "is": "3.2.1"
       }
     },
     "normalize-path": {
@@ -2087,7 +2096,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "oauth-sign": {
@@ -2108,8 +2117,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "octicons": {
@@ -2122,7 +2131,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "ordered-read-streams": {
@@ -2131,8 +2140,8 @@
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "dev": true,
       "requires": {
-        "is-stream": "^1.0.1",
-        "readable-stream": "^2.0.1"
+        "is-stream": "1.1.0",
+        "readable-stream": "2.3.6"
       }
     },
     "parse-glob": {
@@ -2141,10 +2150,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "is-extglob": {
@@ -2159,7 +2168,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -2187,7 +2196,7 @@
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
-        "through": "~2.3"
+        "through": "2.3.8"
       }
     },
     "pend": {
@@ -2214,7 +2223,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "plugin-error": {
@@ -2223,11 +2232,11 @@
       "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
       "dev": true,
       "requires": {
-        "ansi-cyan": "^0.1.1",
-        "ansi-red": "^0.1.1",
-        "arr-diff": "^1.0.1",
-        "arr-union": "^2.0.1",
-        "extend-shallow": "^1.1.2"
+        "ansi-cyan": "0.1.1",
+        "ansi-red": "0.1.1",
+        "arr-diff": "1.1.0",
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
       }
     },
     "preserve": {
@@ -2266,7 +2275,7 @@
       "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.0"
+        "inherits": "2.0.3"
       }
     },
     "randomatic": {
@@ -2275,8 +2284,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -2285,7 +2294,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -2294,7 +2303,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -2305,7 +2314,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -2316,13 +2325,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "regex-cache": {
@@ -2331,7 +2340,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "remove-trailing-separator": {
@@ -2364,28 +2373,28 @@
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
       },
       "dependencies": {
         "assert-plus": {
@@ -2406,7 +2415,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "caseless": {
@@ -2421,7 +2430,7 @@
           "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
           "dev": true,
           "requires": {
-            "boom": "5.x.x"
+            "boom": "5.2.0"
           },
           "dependencies": {
             "boom": {
@@ -2430,7 +2439,7 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.x.x"
+                "hoek": "4.2.1"
               }
             }
           }
@@ -2441,9 +2450,9 @@
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
+            "asynckit": "0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "^2.1.12"
+            "mime-types": "2.1.18"
           }
         },
         "har-validator": {
@@ -2452,8 +2461,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "^5.1.0",
-            "har-schema": "^2.0.0"
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
           }
         },
         "hawk": {
@@ -2462,10 +2471,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.x.x",
-            "cryptiles": "3.x.x",
-            "hoek": "4.x.x",
-            "sntp": "2.x.x"
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.1",
+            "sntp": "2.1.0"
           }
         },
         "hoek": {
@@ -2480,9 +2489,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
           }
         },
         "qs": {
@@ -2497,7 +2506,7 @@
           "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
           "dev": true,
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         },
         "tunnel-agent": {
@@ -2506,7 +2515,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -2523,7 +2532,7 @@
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "rimraf": {
@@ -2532,7 +2541,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "safe-buffer": {
@@ -2559,7 +2568,7 @@
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "2.x.x"
+        "hoek": "2.16.3"
       }
     },
     "source-map": {
@@ -2574,8 +2583,8 @@
       "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
+        "buffer-from": "1.0.0",
+        "source-map": "0.6.1"
       }
     },
     "sparkles": {
@@ -2590,7 +2599,7 @@
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "dev": true,
       "requires": {
-        "through": "2"
+        "through": "2.3.8"
       }
     },
     "sprintf-js": {
@@ -2604,14 +2613,14 @@
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       },
       "dependencies": {
         "assert-plus": {
@@ -2634,7 +2643,7 @@
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
-        "duplexer": "~0.1.1"
+        "duplexer": "0.1.1"
       }
     },
     "stream-shift": {
@@ -2649,7 +2658,7 @@
       "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "streamifier": {
@@ -2664,7 +2673,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringstream": {
@@ -2679,7 +2688,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-bom": {
@@ -2688,7 +2697,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-bom-stream": {
@@ -2697,8 +2706,8 @@
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "dev": true,
       "requires": {
-        "first-chunk-stream": "^1.0.0",
-        "strip-bom": "^2.0.0"
+        "first-chunk-stream": "1.0.0",
+        "strip-bom": "2.0.0"
       }
     },
     "supports-color": {
@@ -2713,9 +2722,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.2",
-        "inherits": "2"
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
       }
     },
     "through": {
@@ -2730,8 +2739,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "through2-filter": {
@@ -2740,8 +2749,8 @@
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
-        "through2": "~2.0.0",
-        "xtend": "~4.0.0"
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       }
     },
     "time-stamp": {
@@ -2756,7 +2765,7 @@
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1"
+        "extend-shallow": "2.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2765,7 +2774,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -2782,7 +2791,7 @@
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "dev": true,
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "tslib": {
@@ -2797,18 +2806,18 @@
       "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^3.2.0",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.12.1"
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.1",
+        "commander": "2.14.1",
+        "diff": "3.4.0",
+        "glob": "7.1.2",
+        "js-yaml": "3.10.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.5.0",
+        "semver": "5.5.0",
+        "tslib": "1.9.0",
+        "tsutils": "2.21.2"
       },
       "dependencies": {
         "commander": {
@@ -2831,7 +2840,7 @@
       "integrity": "sha512-iaIuyjIUeFLdD39MYdzqBuY7Zv6+uGxSwRH4mf+HuzsnznjFz0R2tGrAe0/JvtNh91WrN8UN/DZRFTZNDuVekA==",
       "dev": true,
       "requires": {
-        "tslib": "^1.8.1"
+        "tslib": "1.9.0"
       }
     },
     "tunnel-agent": {
@@ -2870,8 +2879,8 @@
       "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
       "dev": true,
       "requires": {
-        "json-stable-stringify": "^1.0.0",
-        "through2-filter": "^2.0.0"
+        "json-stable-stringify": "1.0.1",
+        "through2-filter": "2.0.0"
       }
     },
     "url-parse": {
@@ -2880,8 +2889,8 @@
       "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
       "dev": true,
       "requires": {
-        "querystringify": "^2.0.0",
-        "requires-port": "^1.0.0"
+        "querystringify": "2.0.0",
+        "requires-port": "1.0.0"
       }
     },
     "util-deprecate": {
@@ -2908,9 +2917,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -2927,8 +2936,8 @@
       "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
       "dev": true,
       "requires": {
-        "clone": "^0.2.0",
-        "clone-stats": "^0.0.1"
+        "clone": "0.2.0",
+        "clone-stats": "0.0.1"
       }
     },
     "vinyl-fs": {
@@ -2937,23 +2946,23 @@
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "dev": true,
       "requires": {
-        "duplexify": "^3.2.0",
-        "glob-stream": "^5.3.2",
-        "graceful-fs": "^4.0.0",
+        "duplexify": "3.5.4",
+        "glob-stream": "5.3.5",
+        "graceful-fs": "4.1.11",
         "gulp-sourcemaps": "1.6.0",
-        "is-valid-glob": "^0.3.0",
-        "lazystream": "^1.0.0",
-        "lodash.isequal": "^4.0.0",
-        "merge-stream": "^1.0.0",
-        "mkdirp": "^0.5.0",
-        "object-assign": "^4.0.0",
-        "readable-stream": "^2.0.4",
-        "strip-bom": "^2.0.0",
-        "strip-bom-stream": "^1.0.0",
-        "through2": "^2.0.0",
-        "through2-filter": "^2.0.0",
-        "vali-date": "^1.0.0",
-        "vinyl": "^1.0.0"
+        "is-valid-glob": "0.3.0",
+        "lazystream": "1.0.0",
+        "lodash.isequal": "4.5.0",
+        "merge-stream": "1.0.1",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "readable-stream": "2.3.6",
+        "strip-bom": "2.0.0",
+        "strip-bom-stream": "1.0.0",
+        "through2": "2.0.3",
+        "through2-filter": "2.0.0",
+        "vali-date": "1.0.0",
+        "vinyl": "1.2.0"
       },
       "dependencies": {
         "clone": {
@@ -2974,8 +2983,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "^1.0.0",
-            "clone-stats": "^0.0.1",
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
             "replace-ext": "0.0.1"
           }
         }
@@ -2987,8 +2996,8 @@
       "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.3",
-        "vinyl": "^0.4.3"
+        "through2": "2.0.3",
+        "vinyl": "0.4.6"
       }
     },
     "vscode": {
@@ -2997,20 +3006,20 @@
       "integrity": "sha512-nNsfYANLqqNfa2+flHyrIrqSIumIoV7R+R9H3gn0SAzZL3RGPEy8db3EYjXKPW5NEfssj/HZhSMI3J3pMNmhPA==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.2",
-        "gulp-chmod": "^2.0.0",
-        "gulp-filter": "^5.0.1",
+        "glob": "7.1.2",
+        "gulp-chmod": "2.0.0",
+        "gulp-filter": "5.1.0",
         "gulp-gunzip": "1.0.0",
-        "gulp-remote-src": "^0.4.3",
-        "gulp-symdest": "^1.1.0",
-        "gulp-untar": "^0.0.6",
-        "gulp-vinyl-zip": "^2.1.0",
-        "mocha": "^4.0.1",
-        "request": "^2.83.0",
-        "semver": "^5.4.1",
-        "source-map-support": "^0.5.0",
-        "url-parse": "^1.1.9",
-        "vinyl-source-stream": "^1.1.0"
+        "gulp-remote-src": "0.4.3",
+        "gulp-symdest": "1.1.0",
+        "gulp-untar": "0.0.6",
+        "gulp-vinyl-zip": "2.1.0",
+        "mocha": "4.1.0",
+        "request": "2.85.0",
+        "semver": "5.5.0",
+        "source-map-support": "0.5.5",
+        "url-parse": "1.4.0",
+        "vinyl-source-stream": "1.1.2"
       },
       "dependencies": {
         "commander": {
@@ -3076,7 +3085,7 @@
           "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "2.0.0"
           }
         }
       }
@@ -3111,8 +3120,8 @@
       "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
       "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
       "requires": {
-        "argparse": "^1.0.7",
-        "glob": "^7.0.5"
+        "argparse": "1.0.10",
+        "glob": "7.1.2"
       }
     },
     "yauzl": {
@@ -3121,8 +3130,8 @@
       "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "0.2.13",
+        "fd-slicer": "1.0.1"
       }
     },
     "yazl": {
@@ -3131,7 +3140,7 @@
       "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "~0.2.3"
+        "buffer-crc32": "0.2.13"
       }
     }
   }

--- a/authoring-extension/package.json
+++ b/authoring-extension/package.json
@@ -115,6 +115,7 @@
     "@types/lodash.merge": "^4.6.3",
     "@types/mocha": "^2.2.32",
     "@types/node": "^7.0.61",
+    "@types/node-dir": "0.0.32",
     "@types/yamljs": "^0.2.30",
     "chai": "^3.5.0",
     "mocha": "^2.3.3",


### PR DESCRIPTION
Was just reading through the code and VS Code was complaining that it couldn't figure out the typings after I did npm install.
Most of the lock file changes were actually caused by my initial `npm install`, but I'll call those out inline.