### PR TITLE
Integrate template extension into docs-markdown

### DIFF
--- a/authoring-extension/src/controllers/quick-pick-menu-controller.ts
+++ b/authoring-extension/src/controllers/quick-pick-menu-controller.ts
@@ -83,16 +83,17 @@ export function markdownQuickPick() {
     );
     // check for active docs-article-templates extension.  if active, add to quickpick menu.
     try {
-        if (vscode.extensions.getExtension("docsmsft.docs-article-templates").isActive === true) {
+        if (vscode.extensions.getExtension("docsmsft.docs-article-templates").isActive) {
             items.push({
                 description: "",
                 label: "$(diff) Template",
             });
         }
     } catch (error) {
-        common.generateTimestamp();
-        output.appendLine(common.msTimeValue + " - The docs-article-templates extension is not installed.");
+        const { msTimeValue } = common.generateTimestamp();
+        output.appendLine("[" + msTimeValue + "]" + " - The docs-article-templates extension is not installed.");
     }
+
     vscode.window.showQuickPick(items, opts).then((selection) => {
         if (!selection) {
             return;
@@ -150,8 +151,8 @@ export function markdownQuickPick() {
                 applyTemplate();
                 break;
             default:
-                common.generateTimestamp();
-                output.appendLine(common.msTimeValue + " - No quickpick case was hit.");
+                const { msTimeValue } = common.generateTimestamp();
+                output.appendLine(msTimeValue + " - No quickpick case was hit.");
         }
     });
 }

--- a/authoring-extension/src/controllers/quick-pick-menu-controller.ts
+++ b/authoring-extension/src/controllers/quick-pick-menu-controller.ts
@@ -1,6 +1,8 @@
 "use strict";
 
 import * as vscode from "vscode";
+import { output } from "../extension";
+import * as common from "../helper/common";
 import * as log from "../helper/log";
 import { insertAlert } from "./alert-controller";
 import { formatBold } from "./bold-controller";
@@ -12,6 +14,7 @@ import { insertImage, insertVideo, selectLinkType } from "./media-controller";
 import { previewTopic } from "./preview-controller";
 import { insertSnippet } from "./snippet-controller";
 import { insertTable } from "./table-controller";
+import { applyTemplate } from "./template-controller";
 
 export function quickPickMenuCommand() {
     const commands = [
@@ -22,6 +25,74 @@ export function quickPickMenuCommand() {
 
 export function markdownQuickPick() {
     log.telemetry(markdownQuickPick.name, "");
+    const opts: vscode.QuickPickOptions = { placeHolder: "Which Markdown command would you like to run?" };
+    const items: vscode.QuickPickItem[] = [];
+    items.push(
+        {
+            description: "",
+            label: "$(pencil) Bold",
+        },
+        {
+            description: "",
+            label: "$(info) Italic",
+        },
+        {
+            description: "",
+            label: "$(code) Code",
+        },
+        {
+            description: "Insert note, tip, important, caution, or warning",
+            label: "$(alert) Alert",
+        },
+        {
+            description: "",
+            label: "$(list-ordered) Numbered list",
+        },
+        {
+            description: "",
+            label: "$(list-unordered) Bulleted list",
+        },
+        {
+            description: "",
+            label: "$(diff-added) Table",
+        },
+        {
+            description: "Insert internal or external link",
+            label: "$(link) Link",
+        },
+        {
+            description: "",
+            label: "$(file-media) Image",
+        },
+        {
+            description: "",
+            label: "$(clippy) Include",
+        },
+        {
+            description: "",
+            label: "$(file-code) Snippets",
+        },
+        {
+            description: "",
+            label: "$(device-camera-video) Video",
+        },
+        {
+            description: "",
+            label: "$(browser) Preview",
+        },
+    );
+    // check for active docs-article-templates extension.  if active, add to quickpick menu.
+    try {
+        if (vscode.extensions.getExtension("docsmsft.docs-article-templates").isActive === true) {
+            items.push({
+                description: "",
+                label: "$(diff) Template",
+            });
+        }
+    } catch (error) {
+        common.generateTimestamp();
+        output.appendLine(common.msTimeValue + " - The docs-article-templates extension is not installed.");
+    }
     vscode.window.showQuickPick(items, opts).then((selection) => {
         if (!selection) {
             return;
@@ -75,65 +146,12 @@ export function markdownQuickPick() {
             case "preview":
                 previewTopic();
                 break;
+            case "template":
+                applyTemplate();
+                break;
             default:
-                // tslint:disable-next-line:no-console
-                console.log("No case was hit");
+                common.generateTimestamp();
+                output.appendLine(common.msTimeValue + " - No quickpick case was hit.");
         }
     });
 }
-
-const opts: vscode.QuickPickOptions = { placeHolder: "Which Markdown command would you like to run?" };
-const items: vscode.QuickPickItem[] = [
-    {
-        description: "",
-        label: "$(pencil) Bold",
-    },
-    {
-        description: "",
-        label: "$(info) Italic",
-    },
-    {
-        description: "",
-        label: "$(code) Code",
-    },
-    {
-        description: "Insert note, tip, important, caution, or warning",
-        label: "$(alert) Alert",
-    },
-    {
-        description: "",
-        label: "$(list-ordered) Numbered list",
-    },
-    {
-        description: "",
-        label: "$(list-unordered) Bulleted list",
-    },
-    {
-        description: "",
-        label: "$(diff-added) Table",
-    },
-    {
-        description: "Insert internal or external link",
-        label: "$(link) Link",
-    },
-    {
-        description: "",
-        label: "$(file-media) Image",
-    },
-    {
-        description: "",
-        label: "$(clippy) Include",
-    },
-    {
-        description: "",
-        label: "$(file-code) Snippets",
-    },
-    {
-        description: "",
-        label: "$(device-camera-video) Video",
-    },
-    {
-        description: "",
-        label: "$(browser) Preview",
-    },
-];

--- a/authoring-extension/src/controllers/template-controller.ts
+++ b/authoring-extension/src/controllers/template-controller.ts
@@ -1,0 +1,19 @@
+"use strict";
+
+import * as vscode from "vscode";
+import { reporter } from "../telemetry/telemetry";
+
+const telemetryCommand: string = "applyTemplate";
+
+export function applyTemplateCommand() {
+    const commands = [
+        { command: applyTemplate.name, callback: applyTemplate },
+    ];
+    return commands;
+}
+
+export function applyTemplate() {
+    reporter.sendTelemetryEvent("command", { command: telemetryCommand });
+    vscode.commands.executeCommand("applyTemplate").then(
+        (err) => vscode.window.showErrorMessage("Docs-article-templates extension is not installed or disabled."));
+}

--- a/authoring-extension/src/extension.ts
+++ b/authoring-extension/src/extension.ts
@@ -23,6 +23,8 @@ import * as log from "./helper/log";
 import { UiHelper } from "./helper/ui";
 import { Reporter } from "./telemetry/telemetry";
 
+export let output: any;
+
 /**
  * Provides the commands to the extension. This method is called when extension is activated.
  * Extension is activated the very first time the command is executed.
@@ -36,6 +38,9 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Places "Docs Markdown Authoring" into the Toolbar
     new UiHelper().LoadToolbar();
+
+    // create global output channel to pass information to the user.
+    createOutputChannel();
 
     // Creates an array of commands from each command file.
     const AuthoringCommands: any = [];
@@ -81,6 +86,11 @@ export function activate(context: vscode.ExtensionContext) {
                 });
         }
     });
+}
+
+// global output channel to pass information to the user.
+export function createOutputChannel() {
+    output = vscode.window.createOutputChannel("Docs Markdown");
 }
 
 // this method is called when your extension is deactivated

--- a/authoring-extension/src/helper/common.ts
+++ b/authoring-extension/src/helper/common.ts
@@ -4,6 +4,9 @@ import os = require("os");
 import * as vscode from "vscode";
 import * as log from "./log";
 
+export let msDateValue: string = "";
+export let msTimeValue: string = "";
+
 /**
  * Provide current os platform
  */
@@ -259,4 +262,20 @@ export function isMarkdownFileCheck(editor: vscode.TextEditor, languageId: boole
  */
 export enum LogType {
     Telemetry, Trace,
+}
+
+/**
+ * Create timestamp
+ */
+export function generateTimestamp() {
+    const date = new Date(Date.now());
+    const currentYear = date.getFullYear();
+    // In Javascript, the month starts from 0 to 11, so we must add 1 to get the current month
+    const currentMonth = (date.getMonth() + 1);
+    const currentDay = date.getDate();
+    const currentHour = date.getHours();
+    const currentMinute = date.getMinutes();
+    const currentSeconds = date.getSeconds();
+    msDateValue = currentMonth + "/" + currentDay + "/" + currentYear;
+    msTimeValue = currentHour + ":" + currentMinute + ":" + currentSeconds;
 }

--- a/authoring-extension/src/helper/common.ts
+++ b/authoring-extension/src/helper/common.ts
@@ -4,9 +4,6 @@ import os = require("os");
 import * as vscode from "vscode";
 import * as log from "./log";
 
-export let msDateValue: string = "";
-export let msTimeValue: string = "";
-
 /**
  * Provide current os platform
  */
@@ -269,13 +266,8 @@ export enum LogType {
  */
 export function generateTimestamp() {
     const date = new Date(Date.now());
-    const currentYear = date.getFullYear();
-    // In Javascript, the month starts from 0 to 11, so we must add 1 to get the current month
-    const currentMonth = (date.getMonth() + 1);
-    const currentDay = date.getDate();
-    const currentHour = date.getHours();
-    const currentMinute = date.getMinutes();
-    const currentSeconds = date.getSeconds();
-    msDateValue = currentMonth + "/" + currentDay + "/" + currentYear;
-    msTimeValue = currentHour + ":" + currentMinute + ":" + currentSeconds;
+    return {
+        msDateValue: date.toLocaleDateString("en-us"),
+        msTimeValue: date.toLocaleTimeString([], { hour12: false }),
+    };
 }


### PR DESCRIPTION
1. [quick-pick-menu-controller] Move quick pick options and item array to the beginning of the markdownQuickPick function.  This was done to build out the quickpick list prior to showing the dropdown (check for dependent extensions).

2. [quick-pick-menu-controller] Start writing errors/helpful info to the output window instead of console for user awareness.

3. [template-controller] Added template-controller to call the applyTemplate command if the extension is installed.

4. [common] Add function to gather datetime information for timestamps.

5. [extension] Create function to create an output channel for the docs-markdown extension on load.