### PR TITLE
Jamarw/expand extension check conditional toolbar

### DIFF
--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,15 +1,27 @@
 # Change Log
 
+## 0.1.0 (-------)
+
+- Template extension integration
+- Fix paths related to docs-markdown folder rename
+- MacOS and Linux external bookmark logic updates
+- Snippet support for CommonMark markdown implementation
+- Updates to command palette and keybindings
+
 ## 0.0.3 (May 10th, 2018)
+
 - Vim extension compatibility fix
 - Update QuickPick menu description
 
 ## 0.0.2 (April 30th, 2018)
+
 - Updates to active workspace verification
 - Documentation updates
 
 ## 0.0.1 (April 3rd, 2018)
+
 First release with the following functionality:
+
 - Text formatting (bold, italic and code)
 - Alerts
 - Links

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -142,8 +142,8 @@
         },
         {
           "command": "formatItalic",
-          "title": "Italic",
-          "category": "Docs"
+          "group": "Docs",
+          "when": "resourceLangId == markdown"
         },
         {
           "command": "formatCode",

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {

--- a/docs-markdown/src/controllers/quick-pick-menu-controller.ts
+++ b/docs-markdown/src/controllers/quick-pick-menu-controller.ts
@@ -75,17 +75,17 @@ export function markdownQuickPick() {
         {
             description: "",
             label: "$(device-camera-video) Video",
-        }
+        },
     );
 
-    if (checkExtension("docsmsft.docs-preview")) {
+    if (common.checkExtension("docsmsft.docs-preview")) {
         items.push({
             description: "",
             label: "$(browser) Preview",
         });
     }
-    // check for active docs-article-templates extension.  if active, add to quickpick menu.
-    if (checkExtension("docsmsft.docs-article-templates")) {
+
+    if (common.checkExtension("docsmsft.docs-article-templates")) {
         items.push({
             description: "",
             label: "$(diff) Template",
@@ -153,15 +153,4 @@ export function markdownQuickPick() {
                 output.appendLine(msTimeValue + " - No quickpick case was hit.");
         }
     });
-}
-
-function checkExtension (extensionName: string) {
-    const friendlyName = extensionName.split('.').reverse()[0];
-    try {
-        return vscode.extensions.getExtension(extensionName).isActive;
-    } catch (error) {
-        const { msTimeValue } = common.generateTimestamp();
-        output.appendLine(`[${msTimeValue}] - The ${friendlyName} extension is not installed.`);
-        return false;
-    }
 }

--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -19,6 +19,7 @@ import { previewTopicCommand } from "./controllers/preview-controller";
 import { quickPickMenuCommand } from "./controllers/quick-pick-menu-controller";
 import { insertSnippetCommand } from "./controllers/snippet-controller";
 import { insertTableCommand } from "./controllers/table-controller";
+import { checkExtension, generateTimestamp } from "./helper/common";
 import * as log from "./helper/log";
 import { UiHelper } from "./helper/ui";
 import { Reporter } from "./telemetry/telemetry";
@@ -41,6 +42,9 @@ export function activate(context: vscode.ExtensionContext) {
 
     // create global output channel to pass information to the user.
     createOutputChannel();
+
+    // check for docs extensions
+    installedExtensionsCheck();
 
     // Creates an array of commands from each command file.
     const AuthoringCommands: any = [];
@@ -91,6 +95,20 @@ export function activate(context: vscode.ExtensionContext) {
 // global output channel to pass information to the user.
 export function createOutputChannel() {
     output = vscode.window.createOutputChannel("Docs Markdown");
+}
+
+export function installedExtensionsCheck() {
+    // create a list to house docs extension names, loop through
+    const docsExtensions = [
+        "docsmsft.docs-article-templates",
+        "docsmsft.preview",
+    ];
+    const { msTimeValue } = generateTimestamp();
+    docsExtensions.forEach((extensionName) => {
+        const friendlyName = extensionName.split(".").reverse()[0];
+        const inactiveMessage = `[${msTimeValue}] - The ${friendlyName} extension is not installed.`;
+        checkExtension(extensionName, inactiveMessage);
+    });
 }
 
 // this method is called when your extension is deactivated

--- a/docs-markdown/src/helper/common.ts
+++ b/docs-markdown/src/helper/common.ts
@@ -2,6 +2,7 @@
 
 import os = require("os");
 import * as vscode from "vscode";
+import { output } from "../extension";
 import * as log from "./log";
 
 /**
@@ -270,4 +271,18 @@ export function generateTimestamp() {
         msDateValue: date.toLocaleDateString("en-us"),
         msTimeValue: date.toLocaleTimeString([], { hour12: false }),
     };
+}
+
+/**
+ * Check for active extensions
+ */
+export function checkExtension(extensionName: string, notInstalledMessage?: string) {
+    try {
+        return vscode.extensions.getExtension(extensionName).isActive;
+    } catch (error) {
+        if (notInstalledMessage) {
+            output.appendLine(notInstalledMessage);
+        }
+        return false;
+    }
 }

--- a/docs-markdown/src/helper/ui.ts
+++ b/docs-markdown/src/helper/ui.ts
@@ -1,6 +1,7 @@
 "use-strict";
 
 import * as vscode from "vscode";
+import * as common from "../helper/common";
 import * as log from "./log";
 
 export class UiHelper {
@@ -13,6 +14,10 @@ export class UiHelper {
             try {
                 this.uiMessage();
                 log.debug("Loaded UI Message Text");
+                if (common.checkExtension("docsmsft.docs-article-templates")) {
+                    this.uiTemplate();
+                    log.debug("Loaded UI Apply Template");
+                }
                 this.uiBold();
                 log.debug("Loaded UI Format Bold");
                 this.uiItalic();
@@ -35,8 +40,10 @@ export class UiHelper {
                 log.debug("Loaded UI Insert Include");
                 this.uiSnippet();
                 log.debug("Loaded UI Insert Snippet");
-                this.uiPreview();
-                log.debug("Loaded UI Insert Preview");
+                if (common.checkExtension("docsmsft.docs-preview")) {
+                    this.uiPreview();
+                    log.debug("Loaded UI Insert Preview");
+                }
             } catch (error) {
                 log.error("Failed to load UI: " + error);
             }
@@ -171,5 +178,15 @@ export class UiHelper {
         statusBarItem.tooltip = "Preview";
         statusBarItem.show();
         statusBarItem.command = "previewTopic";
+    }
+
+    private uiTemplate() {
+        let statusBarItem: vscode.StatusBarItem;
+        statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+        statusBarItem.text = "$(file-text)";
+        statusBarItem.color = "white";
+        statusBarItem.tooltip = "Template";
+        statusBarItem.show();
+        statusBarItem.command = "applyTemplate";
     }
 }


### PR DESCRIPTION
1. Move check extension function from quick-pick-menu-controller to common.
2. Add installed extension check to extension.ts.  This change reduces the number of times the checkExtension function writes to the output window by only writing on load.
3. Add an optional message parameter to the checkExtension function to limit redundant output messages.
4. Update the legacy toolbar to only show template and preview icons if active.
5. TSLint updates