### PR TITLE
Revert "Fix bug while stopping markdocs server"

### DIFF
--- a/docs-preview/src/server.ts
+++ b/docs-preview/src/server.ts
@@ -71,8 +71,7 @@ export class MarkdocsServer {
     }
 
     public stopMarkdocsServer() {
-        const hasStarted = await this.hasAlreadyStartAsync();
-        if (hasStarted)
+        if (this.hasAlreadyStartAsync())
         {
             this.spawnProcess.kill();
         }


### PR DESCRIPTION
Reverts Microsoft/vscode-docs-authoring#72

Mistakenly merged.  We have an error with await being used in a non-async function.

{
	"resource": "/d:/GitHub/vscode-docs-authoring/docs-preview/src/server.ts",
	"owner": "typescript",
	"code": "1308",
	"severity": 8,
	"message": "'await' expression is only allowed within an async function.",
	"source": "ts",
	"startLineNumber": 74,
	"startColumn": 28,
	"endLineNumber": 74,
	"endColumn": 33
}