### PR TITLE
remove quickpick from navigation menu

### DIFF
--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.1.2 (June 20th, 2018)
+
+- Remove quickpick button from navigation menu
+
 ## 0.1.1 (June 20th, 2018)
 
 - Update readme links

--- a/docs-markdown/package-lock.json
+++ b/docs-markdown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-markdown",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1566,10 +1566,13 @@
       }
     },
     "octicons": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/octicons/-/octicons-4.4.0.tgz",
-      "integrity": "sha1-rKO9MvXcHZB6jQ3nRPeODFThlEY=",
-      "dev": true
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/octicons/-/octicons-7.3.0.tgz",
+      "integrity": "sha512-UVjlkmUL15Ef/7Rd72Io634Bdl61QgSMasAZpvXPoR2XNFj1RelAyhl4QJuR1hBGlPWFDR7KFj2jEzsFax2IUg==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {
@@ -114,12 +114,6 @@
           "when": "resourceLangId == markdown",
           "command": "markdown.showPreview",
           "alt": "markdown.showPreviewToSide",
-          "group": "navigation"
-        },
-        {
-          "when": "resourceLangId == markdown",
-          "command": "markdownQuickPick",
-          "alt": "markdownQuickPick",
           "group": "navigation"
         }
       ],
@@ -297,7 +291,7 @@
     "@types/yamljs": "^0.2.30",
     "chai": "^3.5.0",
     "mocha": "^5.2.0",
-    "octicons": "^4.4.0",
+    "octicons": "^7.3.0",
     "tslint": "^5.9.1",
     "typescript": "^2.8.3",
     "vscode": "^1.1.18"


### PR DESCRIPTION
1. Remove markdownQuickPick command from navigation menu.
2. Update version and changelog.
3. Remove redundant octicons dependency and update mocha to resolve security vulnerabilities.

Resolves issue:
https://github.com/Microsoft/vscode-docs-authoring/issues/82