### PR TITLE
chore: Update Changelog date for docs-markdown

### DIFF
--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.1.2 (June 20th, 2018)
+## 0.1.2 (July 3rd, 2018)
 
 - Remove quickpick button from navigation menu
 


### PR DESCRIPTION
I think I only noticed this pushed out today, but used the date from 80d61a7ea481774aa1e9ad5e4d85f89667807d47