### PR TITLE
Merge master redirect updates into link ui branch

### DIFF
--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -25,6 +25,7 @@ import { UiHelper } from "./helper/ui";
 import { Reporter } from "./telemetry/telemetry";
 
 export const output = vscode.window.createOutputChannel("docs-markdown");
+export const masterRedirectOutput = vscode.window.createOutputChannel("docs-markdown-master-redirect");
 
 /**
  * Provides the commands to the extension. This method is called when extension is activated.


### PR DESCRIPTION
Link-ui-changes branch contains structure changes due to refactoring and the changes in the master-redirect-updates branch were made based on that structure.  Figured going into link-ui branch with a smaller number of changes would be easier to review.

1. Additional information in notification pop-up.
2. Single output window stream (docs-markdown-master-redirect) with verbose logging.
3. Better error-handling with json interactions.
4. Improved filter logic to reduce the number of files that are parsed.
5. New function to standardize messaging.