### PR TITLE
Update toolbar link options and heading level support

### DIFF
--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.1.4 (TBD)
+
+- Update toolbar link options
+- Bookmarks/headings no longer link to H1; H2-H6 are still supported
+
 ## 0.1.3 (August 2nd, 2018)
 
 - Link UI updates

--- a/docs-markdown/package-lock.json
+++ b/docs-markdown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-markdown",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {

--- a/docs-markdown/src/controllers/bookmark-controller.ts
+++ b/docs-markdown/src/controllers/bookmark-controller.ts
@@ -9,7 +9,7 @@ import { reporter } from "../telemetry/telemetry";
 const telemetryCommand: string = "insertBookmark";
 const markdownExtensionFilter = [".md"];
 
-export const headingTextRegex = /^ {0,3}(#{1,6})(.*)/gm;
+export const headingTextRegex = /^ {0,3}(#{2,6})(.*)/gm;
 export const yamlTextRegex = /^-{3}\s*\r?\n([\s\S]*?)-{3}\s*\r?\n([\s\S]*)/;
 
 export function insertBookmarkCommands() {

--- a/docs-markdown/src/controllers/media-controller.ts
+++ b/docs-markdown/src/controllers/media-controller.ts
@@ -16,6 +16,7 @@ export function insertLinksAndMediaCommands() {
         { command: insertLink.name, callback: insertLink },
         { command: insertImage.name, callback: insertImage },
         { command: selectLinkType.name, callback: selectLinkType },
+        { command: selectLinkTypeToolbar.name, callback: selectLinkTypeToolbar },
         { command: selectMediaType.name, callback: selectMediaType },
     ];
     return commands;
@@ -298,6 +299,38 @@ export function selectLinkType() {
             if (qpSelection === linkTypes[0]) {
                 insertBookmarkInternal();
             } else if (qpSelection === linkTypes[1]) {
+                insertBookmarkExternal();
+            }
+        });
+    }
+}
+
+/**
+ * Creates an entry point for creating an internal (link type) or external link (url type).
+ */
+export function selectLinkTypeToolbar() {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        noActiveEditorMessage();
+        return;
+    } else {
+        if (!isValidEditor(editor, false, "insert link")) {
+            return;
+        }
+
+        if (!isMarkdownFileCheck(editor, false)) {
+            return;
+        }
+
+        const linkTypes = ["External", "Internal", "Bookmark in this file", "Bookmark in another file"];
+        vscode.window.showQuickPick(linkTypes).then((qpSelection) => {
+            if (qpSelection === linkTypes[0]) {
+                insertURL();
+            } else if (qpSelection === linkTypes[1]) {
+                Insert(false);
+            } else if (qpSelection === linkTypes[2]) {
+                insertBookmarkInternal();
+            } else if (qpSelection === linkTypes[3]) {
                 insertBookmarkExternal();
             }
         });

--- a/docs-markdown/src/controllers/media-controller.ts
+++ b/docs-markdown/src/controllers/media-controller.ts
@@ -308,33 +308,33 @@ export function selectLinkType() {
 /**
  * Creates an entry point for creating an internal (link type) or external link (url type).
  */
-export function selectLinkTypeToolbar() {
+export function selectLinkTypeToolbar(toolbar?: boolean) {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
         noActiveEditorMessage();
         return;
-    } else {
-        if (!isValidEditor(editor, false, "insert link")) {
-            return;
-        }
-
-        if (!isMarkdownFileCheck(editor, false)) {
-            return;
-        }
-
-        const linkTypes = ["External", "Internal", "Bookmark in this file", "Bookmark in another file"];
-        vscode.window.showQuickPick(linkTypes).then((qpSelection) => {
-            if (qpSelection === linkTypes[0]) {
-                insertURL();
-            } else if (qpSelection === linkTypes[1]) {
-                Insert(false);
-            } else if (qpSelection === linkTypes[2]) {
-                insertBookmarkInternal();
-            } else if (qpSelection === linkTypes[3]) {
-                insertBookmarkExternal();
-            }
-        });
     }
+
+    if (!isValidEditor(editor, false, "insert link")) {
+        return;
+    }
+
+    if (!isMarkdownFileCheck(editor, false)) {
+        return;
+    }
+
+    const linkTypes = ["External", "Internal", "Bookmark in this file", "Bookmark in another file"];
+    vscode.window.showQuickPick(linkTypes).then((qpSelection) => {
+        if (qpSelection === linkTypes[0]) {
+            insertURL();
+        } else if (qpSelection === linkTypes[1]) {
+            Insert(false);
+        } else if (qpSelection === linkTypes[2]) {
+            insertBookmarkInternal();
+        } else if (qpSelection === linkTypes[3]) {
+            insertBookmarkExternal();
+        }
+    });
 }
 
 /**

--- a/docs-markdown/src/helper/ui.ts
+++ b/docs-markdown/src/helper/ui.ts
@@ -68,7 +68,7 @@ export class UiHelper {
         statusBarItem.color = "white";
         statusBarItem.tooltip = "Insert Link";
         statusBarItem.show();
-        statusBarItem.command = "selectLinkType";
+        statusBarItem.command = "selectLinkTypeToolbar";
     }
 
     private uiImage() {


### PR DESCRIPTION
1. Add new function to add external and internal link options to toolbar link command
2. Change bookmark/heading command to support h2-h6 (no more h1)

Resolves issue [94](https://github.com/Microsoft/vscode-docs-authoring/issues/94)