### PR TITLE
Improve handling of redirect_document_id Boolean

### DIFF
--- a/docs-markdown/src/controllers/master-redirect-controller.ts
+++ b/docs-markdown/src/controllers/master-redirect-controller.ts
@@ -40,12 +40,13 @@ export class RedirectionFile {
     // Members mapping to JSON elements in master redirection file
     public source_path: string;
     public redirect_url: string;
-    public redirect_document_id: boolean = false;
+    public redirect_document_id: boolean;
 
-    constructor(filePath: string, redirectUrl: string) {
+    constructor(filePath: string, redirectUrl: string, redirectDocumentId: boolean) {
         this.fileFullPath = filePath;
         this.source_path = this.getRelativePathToRoot(filePath);
         this.redirect_url = redirectUrl;
+        this.redirect_document_id = redirectDocumentId;
     }
 
     public getRelativePathToRoot(filePath: any): string {
@@ -122,7 +123,11 @@ function generateMasterRedirectionFile() {
                             const yamlHeader = YAML.parse(metadataContent.toLowerCase());
 
                             if (yamlHeader != null && yamlHeader.redirect_url != null) {
-                                redirectionFiles.push(new RedirectionFile(file, yamlHeader.redirect_url));
+                                if (yamlHeader.redirect_document_id != null) {
+                                    redirectionFiles.push(new RedirectionFile(file, yamlHeader.redirect_url, yamlHeader.redirect_document_id));
+                                } else {
+                                    redirectionFiles.push(new RedirectionFile(file, yamlHeader.redirect_url, false));
+                                }
                                 showStatusMessage("Added " + file + " to list.");
                             }
                         }


### PR DESCRIPTION
1. Removed redirect_document_id hardcoded 'false' value.
1. Updated logic to check for a valid yaml header and redirect_url attribute.  If this check passes, then check for the redirect_document_id attribute.

**Expected results for redirect_document_id attribute**
If present and true: value is true
If present and false: value is false
If redirect_document_id attribute is not present: value is false
If redirect_document_id attribute is present but value is empty: value is false