### PR TITLE
Update unit test suite

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -296,7 +296,7 @@
     "vscode:prepublish": "tsc -p ./",
     "compile": "tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
-    "test": "node ./node_modules/vscode/bin/test",
+    "test": "node ./node_modules/vscode/bin/test && jest tests ./test/markdownlint-custom-rules",
     "test-rules": "jest tests ./test/markdownlint-custom-rules"
   },
   "dependencies": {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -297,7 +297,8 @@
     "compile": "tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "node ./node_modules/vscode/bin/test && jest tests ./test/markdownlint-custom-rules",
-    "test-rules": "jest tests ./test/markdownlint-custom-rules"
+    "test-rules": "jest tests ./test/markdownlint-custom-rules",
+    "test-core": "node ./node_modules/vscode/bin/test"
   },
   "dependencies": {
     "file-exists": "^5.0.1",

--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -25,7 +25,6 @@ import { Reporter } from "./telemetry/telemetry";
 
 export const output = window.createOutputChannel("docs-markdown");
 export const masterRedirectOutput = window.createOutputChannel("docs-markdown-master-redirect");
-const { msTimeValue } = generateTimestamp();
 
 /**
  * Provides the commands to the extension. This method is called when extension is activated.
@@ -36,6 +35,7 @@ const { msTimeValue } = generateTimestamp();
  * param {vscode.ExtensionContext} the context the extension runs in, provided by vscode on activation of the extension.
  */
 export function activate(context: ExtensionContext) {
+    const { msTimeValue } = generateTimestamp();
     output.appendLine(`[${msTimeValue}] - Activating docs markdown extension.`);
 
     // Places "Docs Markdown Authoring" into the Toolbar
@@ -94,6 +94,7 @@ export function activate(context: ExtensionContext) {
 }
 
 export function installedExtensionsCheck() {
+    const { msTimeValue } = generateTimestamp();
     // create a list to house docs extension names, loop through
     const docsExtensions = [
         "docsmsft.docs-article-templates",
@@ -111,6 +112,7 @@ export function installedExtensionsCheck() {
  * Checks for markdownlint.customRules property.  If markdownlint isn't installed, do nothing.  If markdownlint is installed, check for custom property values.
  */
 export function checkMarkdownlintCustomProperty() {
+    const { msTimeValue } = generateTimestamp();
     const customProperty = "markdownlint.customRules";
     const customRuleset = "{docsmsft.docs-markdown}/markdownlint-custom-rules/rules.js";
     const customPropertyData = workspace.getConfiguration().inspect(customProperty);

--- a/docs-markdown/test/extension.test.ts
+++ b/docs-markdown/test/extension.test.ts
@@ -5,11 +5,12 @@
 
 // The module 'assert' provides assertion methods from node
 // import * as assert from 'assert';
-import { expect } from 'chai';
+import { expect } from "chai";
 
 describe("Ensure Chai Mocha Test Samples Run Correctly", () => {
 
     it("Hey, true returns true! Incredible.", () => {
+        // tslint:disable-next-line:no-unused-expression
         expect(true).to.be.true;
     });
 

--- a/docs-markdown/test/helper/format-styles.test.ts
+++ b/docs-markdown/test/helper/format-styles.test.ts
@@ -1,5 +1,7 @@
-import { isBold, isItalic, isBoldAndItalic, isInlineCode, isMultiLineCode } from '../../src/helper/format-styles';
-import { expect } from 'chai';
+import { expect } from "chai";
+import { isBold, isBoldAndItalic, isInlineCode, isItalic, isMultiLineCode } from "../../src/helper/format-styles";
+
+/* tslint:disable:no-unused-expression */
 
 describe("Format style type checking,", () => {
     const bolded = `**This is sample text in markdown bold format.**`;
@@ -49,7 +51,6 @@ describe("Format style type checking,", () => {
             expect(isMultiLineCode(nonMultiline)).to.be.false;
         });
     });
-
 
     describe("isBold function", () => {
 

--- a/docs-markdown/test/index.ts
+++ b/docs-markdown/test/index.ts
@@ -10,13 +10,14 @@
 // to report the results back to the caller. When the tests are finished, return
 // a possible error to the callback or null if none.
 
-var testRunner = require('vscode/lib/testrunner');
+// tslint:disable-next-line:no-var-requires
+let testRunner = require("vscode/lib/testrunner");
 
 // You can directly control Mocha options by uncommenting the following lines
 // See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
 testRunner.configure({
-    ui: 'bdd', 		// the BDD UI is being used in extension.test.ts (describe, it, should)
-    useColors: true // colored output from test results
+    ui: "bdd", 		// the BDD UI is being used in extension.test.ts (describe, it, should)
+    useColors: true, // colored output from test results
 });
 
 module.exports = testRunner;

--- a/docs-markdown/test/resources/testStrings.ts
+++ b/docs-markdown/test/resources/testStrings.ts
@@ -1,51 +1,51 @@
-'use-strict'
+"use-strict";
 
-//Single line text resources
-export var NonFormattedSingleLineText: string = "This is sample text. Singleline, without formatting.";
-export var CodeFormattedSingleLineText: string = "`This is sample text in a markdown code block.`";
-export var BoldFormattedSingleLineText: string = "**This is sample text in markdown bold format.**";
-export var ItalicFormattedSingleLineText: string = "*This is sample text in markdown italic format.*";
-export var NoteFormattedSingleLineText: string = "> [!NOTE]\r\n> This is sample text formatted as an alert of type \"Note\".";
-export var ImportantFormattedSingleLineText: string = "> [!IMPORTANT]\r\n> This is sample text formatted as an alert of type \"Important\".";
-export var WarningFormattedSingleLineText: string = "> [!WARNING]\r\n> This is sample text formatted as an alert of type \"Warning\".";
-export var TipFormattedSingleLineText: string = "> [!TIP]\r\n> This is sample text formatted as an alert of type \"Tip\".";
-export var NestedSingleLineCodeFormattedSingleLineText: string = "This is sample text with a `Nested Code` block inside it.";
-export var CodeFormattedNestedSingleLineCodeFormattedSingleLineText: string = "`This is sample text with a `Nested Code` block inside it.`";
-export var NestedBoldFormattedSingleLineText: string = "This is sample text with a **Nested Bold** block inside it.";
-export var BoldFormattedNestedBoldFormattedSingleLineText: string = "**This is sample text with a **Nested Bold** block inside it.**";
-export var NestedItalicFormattedSingleLineText: string = "This is sample text with a *Nested Italic* block inside it.";
-export var ItalicFormattedNestedItalicFormattedSingleLineText: string = "*This is sample text with a *Nested Italic* block inside it.*";
+// Single line text resources
+export let NonFormattedSingleLineText: string = "This is sample text. Singleline, without formatting.";
+export let CodeFormattedSingleLineText: string = "`This is sample text in a markdown code block.`";
+export let BoldFormattedSingleLineText: string = "**This is sample text in markdown bold format.**";
+export let ItalicFormattedSingleLineText: string = "*This is sample text in markdown italic format.*";
+export let NoteFormattedSingleLineText: string = "> [!NOTE]\r\n> This is sample text formatted as an alert of type \"Note\".";
+export let ImportantFormattedSingleLineText: string = "> [!IMPORTANT]\r\n> This is sample text formatted as an alert of type \"Important\".";
+export let WarningFormattedSingleLineText: string = "> [!WARNING]\r\n> This is sample text formatted as an alert of type \"Warning\".";
+export let TipFormattedSingleLineText: string = "> [!TIP]\r\n> This is sample text formatted as an alert of type \"Tip\".";
+export let NestedSingleLineCodeFormattedSingleLineText: string = "This is sample text with a `Nested Code` block inside it.";
+export let CodeFormattedNestedSingleLineCodeFormattedSingleLineText: string = "`This is sample text with a `Nested Code` block inside it.`";
+export let NestedBoldFormattedSingleLineText: string = "This is sample text with a **Nested Bold** block inside it.";
+export let BoldFormattedNestedBoldFormattedSingleLineText: string = "**This is sample text with a **Nested Bold** block inside it.**";
+export let NestedItalicFormattedSingleLineText: string = "This is sample text with a *Nested Italic* block inside it.";
+export let ItalicFormattedNestedItalicFormattedSingleLineText: string = "*This is sample text with a *Nested Italic* block inside it.*";
 
-//Multi line text resources. '\' is the multiline escape character for javascript.
-export var NonFormattedMultiLineText: string =
+// Multi line text resources. '\' is the multiline escape character for javascript.
+export let NonFormattedMultiLineText: string =
     "This is sample text.\r\nIt has multiplelines in it.";
-export var CodeFormattedMultilineText: string =
+export let CodeFormattedMultilineText: string =
     "```\nThis is sample text in a markdown multiline code block.\n```\n";
-export var BoldFormattedMultilineText: string =
+export let BoldFormattedMultilineText: string =
     "**This is sample text in\r\nMarkdown bold format, multiline**";
-export var ItalicFormattedMultilineText: string =
+export let ItalicFormattedMultilineText: string =
     "*This is sample text in\r\nMarkdown italic format, multiline*";
-export var NoteFormattedMultilineText: string = "> [!NOTE]\r\n> This is sample text formatted as an alert of type \"Note\".\r\n> This is multiline text.";
-export var ImportantFormattedMultilineText: string = "> [!IMPORTANT]\r\n> This is sample text formatted as an alert of type \"Important\".\r\n> This is multiline text.";
-export var WarningFormattedMultilineText: string = "> [!WARNING]\r\n> This is sample text formatted as an alert of type \"Warning\".\r\n> This is multiline text.";
-export var TipFormattedMultilineText: string = "> [!TIP]\r\n> This is sample text formatted as an alert of type \"Tip\".\r\n> This is multiline text.";
-export var NestedMultilineCodeFormattedMultilineText: string =
+export let NoteFormattedMultilineText: string = "> [!NOTE]\r\n> This is sample text formatted as an alert of type \"Note\".\r\n> This is multiline text.";
+export let ImportantFormattedMultilineText: string = "> [!IMPORTANT]\r\n> This is sample text formatted as an alert of type \"Important\".\r\n> This is multiline text.";
+export let WarningFormattedMultilineText: string = "> [!WARNING]\r\n> This is sample text formatted as an alert of type \"Warning\".\r\n> This is multiline text.";
+export let TipFormattedMultilineText: string = "> [!TIP]\r\n> This is sample text formatted as an alert of type \"Tip\".\r\n> This is multiline text.";
+export let NestedMultilineCodeFormattedMultilineText: string =
     "This is sample text\r\n```\nThis is a\r\n code block\n```\nThere is code nested inside.";
-export var NestedItalicFormatedMultillineText: string =
+export let NestedItalicFormatedMultillineText: string =
     "This is sample text *there\r\nis nested italic* in this block.";
-export var NestedBoldFormatedMultilineText: string =
+export let NestedBoldFormatedMultilineText: string =
     "This is sample text **there\r\nis nested bold** in this block.";
-export var BoldFormattedNestedBoldFormattedMultiLineText: string = "**This is sample text with a **Nested \r\n Bold** block inside it.**";
-export var ItalicFormattedNestedItalicFormattedMultiLineText: string = "*This is sample text with a *Nested \r\n Italic* block inside it.*";
-export var CodeFormattedNestedCodeFormattedMultilineText: string = "```\nThis is sample text with a \r\n```Nested Code \n```\n block inside it.\n```\n";
+export let BoldFormattedNestedBoldFormattedMultiLineText: string = "**This is sample text with a **Nested \r\n Bold** block inside it.**";
+export let ItalicFormattedNestedItalicFormattedMultiLineText: string = "*This is sample text with a *Nested \r\n Italic* block inside it.*";
+export let CodeFormattedNestedCodeFormattedMultilineText: string = "```\nThis is sample text with a \r\n```Nested Code \n```\n block inside it.\n```\n";
 
-//Unformatted Strings with Includes, Art, GUID, Links
-export var sampleGUID = "This is a GUID: 60bbae04-174c-4841-90cf-fae6c3b164fb.";
-export var sampleExternalLink = "This is an external link to bing.com: [Bing](http://www.bing.com)";
-export var sampleInternalLink = "This is an internal link to a relative path: [A relative path](..\..\README.md)";
-export var sampleArtLink = "An art link: ![Additionally](../media/link-checker-1.png)";
-export var sampleInclude = "[!INCLUDE [README](../../README.md)]";
+// Unformatted Strings with Includes, Art, GUID, Links
+export let sampleGUID = "This is a GUID: 60bbae04-174c-4841-90cf-fae6c3b164fb.";
+export let sampleExternalLink = "This is an external link to bing.com: [Bing](http://www.bing.com)";
+export let sampleInternalLink = "This is an internal link to a relative path: [A relative path](..\..\README.md)";
+export let sampleArtLink = "An art link: ![Additionally](../media/link-checker-1.png)";
+export let sampleInclude = "[!INCLUDE [README](../../README.md)]";
 
-//Bookmark duplicate string
-export var duplicateBookmarkString: string[] = ["# Test\r\n", "# Test\r\n", "## Test\r\n"];
-export var expectBookmarkString: string[] = ["# Test\r\n", "# Test (1)\r\n", "## Test\r\n"];
+// Bookmark duplicate string
+export let duplicateBookmarkString: string[] = ["# Test\r\n", "# Test\r\n", "## Test\r\n"];
+export let expectBookmarkString: string[] = ["# Test\r\n", "# Test (1)\r\n", "## Test\r\n"];


### PR DESCRIPTION
1. Update **npm run test** to run full test suite (both core extension functionality and custom linting rules.
1. Add new test command, **test-core**, to run unit tests for 'native' extension functionality.
1. Move generateTimestamp function to within extension.ts functions to unblock core extension unit tests.
1. Fix linting errors in core extension unit tests.

Testing

1. Pull latest code and checkout jamarw/run-full-test-suite branch.
1. Open terminal and navigate to docs-markdown directory in local clone.
1. Run **npm-install**.
1. Run **npm run vscode:prepublish** to compile code.
1. Run **npm run test-rules** (this command should launch four unit tests for markdownlint custom rules).
1. Run **npm run test-core** (this command should launch 23 unit tests for core extension functionality i.e. formatting).
1. Run **npm run test** (this should launch both core and custom rule unit tests).

