### PR TITLE
Add support for friendly template names

### DIFF
--- a/docs-article-templates/src/controllers/quick-pick-controller.ts
+++ b/docs-article-templates/src/controllers/quick-pick-controller.ts
@@ -33,7 +33,6 @@ export function displayTemplates() {
                 !== -1).forEach((file: any) => {
                     if (basename(file).toLowerCase() !== "readme.md") {
                         try {
-                            quickPickMap.set(basename(file), join(dirname(file), basename(file)));
                             const filePath = join(dirname(file), basename(file));
                             const fileContent = readFileSync(filePath, "utf8");
                             const updatedContent = fileContent.replace("{@date}", "{date}");
@@ -43,6 +42,7 @@ export function displayTemplates() {
                             if (templateName) {
                                 quickPickMap.set(templateName, join(dirname(file), basename(file)));
                             }
+
                             if (!templateName) {
                                 quickPickMap.set(basename(file), join(dirname(file), basename(file)));
                             }
@@ -57,11 +57,11 @@ export function displayTemplates() {
         const templates: QuickPickItem[] = [];
         templates.push({ label: moduleQuickPick });
         for (const key of quickPickMap.keys()) {
-            templates.push({ label: key});
+            templates.push({ label: key });
         }
 
         // tslint:disable-next-line:only-arrow-functions
-        templates.sort(function(a, b) {
+        templates.sort(function (a, b) {
             const firstLabel = a.label.toUpperCase();
             const secondLabel = b.label.toUpperCase();
             if (firstLabel < secondLabel) {

--- a/docs-article-templates/src/helper/github.ts
+++ b/docs-article-templates/src/helper/github.ts
@@ -1,7 +1,7 @@
 "use-strict";
 
 import { readdir, stat, unlinkSync } from "fs";
-import {homedir} from "os";
+import { homedir } from "os";
 import { join } from "path";
 import { displayTemplates } from "../controllers/quick-pick-controller";
 import { output } from "../extension";

--- a/docs-article-templates/src/helper/unit-builder.ts
+++ b/docs-article-templates/src/helper/unit-builder.ts
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import { MessageOptions, window, Uri, ViewColumn, TextDocumentShowOptions } from "vscode";
+import { MessageOptions, TextDocumentShowOptions, Uri, ViewColumn, window } from "vscode";
 import { output } from "../extension";
 import { formatLearnNames } from "../helper/common";
 import { formattedModuleName, includesDirectory, modulePath, repoName, updateModule } from "../helper/module-builder";

--- a/docs-article-templates/src/strings.ts
+++ b/docs-article-templates/src/strings.ts
@@ -1,5 +1,5 @@
 // metadata
-export const templateNameMetadata = "template_name";
+export const templateNameMetadata = "docs_authoring_template_name";
 
 // quickpick, input
 export const enterModuleName = "Enter module name";


### PR DESCRIPTION
1. Use map data sctructure to store file and path data.
2. Populate quickpick with map keys (friendly/file names).
3. Linting cleanup.