### PR TITLE
Add units to existing module

### DIFF
--- a/docs-article-templates/src/helper/unit-builder.ts
+++ b/docs-article-templates/src/helper/unit-builder.ts
@@ -129,7 +129,6 @@ export function addUnitToModule(existingModulePath: string) {
     /* tslint:disable:object-literal-sort-keys one-variable-per-declaration */
     const yaml = require('js-yaml');
     const config = yaml.safeLoad(readFileSync(existingModulePath, 'utf8'));
-    // console.log(`This is the uid: ${config.uid}`);
 
     const unitMetadata = {
         "title": unitTitle,

--- a/docs-article-templates/src/strings.ts
+++ b/docs-article-templates/src/strings.ts
@@ -8,3 +8,4 @@ export const enterUnitName = "Enter unit name";
 export const validateUnitName = "Please provide a unit name.";
 export const moduleQuickPick = "Learn module";
 export const parentFolderPrompt = "Select parent folder.";
+export const addUnitToQuickPick = "Add unit to active module";


### PR DESCRIPTION
1. Add conditional quickpick option to  push new unit option to menu if a module file is active/open.  If a user has a module file open (index.yml), a new quickpick option (Add module to unit) will show in the menu.
2. Create new function to handle updating existing modules.  Code will determine if the module already exists or if it's a new module.  If the module exists, the addModuleToUnit function will be called.  This will read the module data, use the existing values, create the new units and update the associated index.yml file.  If it's a new module, there existing functionality remains the same.
3. Remove unused async declarations.
