### PR TITLE
Preserve values when adding a unit

### DIFF
--- a/docs-article-templates/src/helper/unit-builder.ts
+++ b/docs-article-templates/src/helper/unit-builder.ts
@@ -85,7 +85,7 @@ export function createUnits() {
 }
 
 // cleanup unnecessary characters, replace values and open unit in new tab after it's written to disk.
-export function cleanupUnit(generatedUnit: string) {
+export function cleanupUnit(generatedUnit: string, preserveValues?: boolean) {
     try {
         const moduleContent = readFileSync(generatedUnit, "utf8");
         const updatedModule = moduleContent.replace("header: ", "")
@@ -100,7 +100,11 @@ export function cleanupUnit(generatedUnit: string) {
             viewColumn: ViewColumn.One,
         };
         window.showTextDocument(uri, options);
-        updateModule(unitList);
+        if (preserveValues) {
+            window.showInformationMessage(`${generatedUnit} created.  Please add unit to index file.`);
+        } else {
+            updateModule(unitList);
+        }
     } catch (error) {
         output.appendLine(error);
     }
@@ -109,12 +113,6 @@ export function cleanupUnit(generatedUnit: string) {
 // data used to create the unit(s) yml file.
 export function addUnitToModule(existingModulePath: string) {
     let unitPath;
-    const options: MessageOptions = { modal: true };
-    window.showInformationMessage(`Create a new unit? Previous unit: ${unitTitle}`, options, "Yes", "No").then((result) => {
-        if (result === "Yes") {
-            getUnitName();
-        }
-    });
 
     unitList.push(`${learnRepo}.${formattedModuleName}.${formattedUnitName}`);
     const moduleDirectory = parse(existingModulePath).dir;
@@ -153,5 +151,5 @@ export function addUnitToModule(existingModulePath: string) {
     const includeDirectory = join(moduleDirectory, "includes");
     includeFile = join(includeDirectory, `${formattedUnitName}.md`);
     writeFileSync(includeFile, "");
-    cleanupUnit(unitPath);
+    cleanupUnit(unitPath, true);
 }


### PR DESCRIPTION
Found a scenario where optional metadata can be overwritten when a new unit is created.  To prevent overwrites, the code was updated to notify the user instead of automatically updating the module (index.yml). Automatic-updating will be implemented once another solution is found.

1. Add optional preserveValues parameter to cleanupUnit function.
2. Add condition that will notify the user that the index file will need to be updated if a unit was added to an existing module.  New modules and units creation will not change.
3. Remove additional unit prompt from addUnitToModule function.