### PR TITLE
Add local debugging and prep for 0.3.17 release

### DIFF
--- a/docs-preview/.gitignore
+++ b/docs-preview/.gitignore
@@ -4,5 +4,4 @@ out/
 **/bin/
 **/obj/
 **/.vs/
-**/.vscode/
 *.vsix

--- a/docs-preview/.gitignore
+++ b/docs-preview/.gitignore
@@ -5,3 +5,4 @@ out/
 **/obj/
 **/.vs/
 *.vsix
+install.Lock

--- a/docs-preview/.vscode/launch.json
+++ b/docs-preview/.vscode/launch.json
@@ -1,0 +1,41 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+{
+    "version": "0.1.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach by Process ID",
+            "processId": "${command:PickProcess}"
+        },
+        {
+            "name": "Launch Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceRoot}"
+            ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outDir": "${workspaceRoot}/out/src",
+            "preLaunchTask": "npm"
+        },
+        {
+            "name": "Launch Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceRoot}",
+                "--extensionTestsPath=${workspaceRoot}/out/test"
+            ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [
+                "${workspaceRoot}/out/test"
+            ],
+            "preLaunchTask": "npm"
+        }
+    ]
+}

--- a/docs-preview/.vscode/settings.json
+++ b/docs-preview/.vscode/settings.json
@@ -1,0 +1,11 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        "out": false // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true // set this to false to include "out" folder in search results
+    },
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "editor.formatOnSave": true // we want to use the TS server from our node_modules folder to control its version
+}

--- a/docs-preview/.vscode/tasks.json
+++ b/docs-preview/.vscode/tasks.json
@@ -1,0 +1,30 @@
+// Available variables which can be used inside of strings.
+// ${workspaceRoot}: the root folder of the team
+// ${file}: the current opened file
+// ${fileBasename}: the current opened file's basename
+// ${fileDirname}: the current opened file's dirname
+// ${fileExtname}: the current opened file's extension
+// ${cwd}: the current working directory of the spawned process
+
+// A task runner that calls a custom npm script that compiles the extension.
+{
+    "version": "0.1.0",
+
+    // we want to run npm
+    "command": "npm",
+
+    // the command is a shell script
+    "isShellCommand": true,
+
+    // show the output window only if unrecognized errors occur.
+    "showOutput": "silent",
+
+    // we run the custom script "compile" as defined in package.json
+    "args": ["run", "compile", "--loglevel", "silent"],
+
+    // The tsc compiler is started in watching mode
+    "isWatching": true,
+
+    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
+    "problemMatcher": "$tsc-watch"
+}

--- a/docs-preview/README.md
+++ b/docs-preview/README.md
@@ -1,5 +1,7 @@
 # Docs Preview Extension
 
+**Note: Version 0.3.17 uses the VS Code markdown preview environment.  The vscode.previewHtml command was [deprecated](https://github.com/Microsoft/vscode/issues/62630) and the docs-preview service is being updated to support this change.  Custom markdown rendering will be affected until a new version of the extension is released.**
+
 This extension uses the docs.microsoft.com CSS to provide more accurate preview for Markdown published to Docs via the Open Publishing System (OPS). This includes all Markdown as supported by the CommonMark specification, as well as custom Markdown syntax for Docs, such as:
 
 - Alerts (note, tip, important, caution, and warning).

--- a/docs-preview/changelog.md
+++ b/docs-preview/changelog.md
@@ -1,0 +1,5 @@
+# Change Log
+
+## 0.3.17 (April 16th, 2019)
+
+- Update preview command to use VS Code rendering environment.  Docs-preview functionality is actively under development to support vscode.previewHtml command deprecation.

--- a/docs-preview/package-lock.json
+++ b/docs-preview/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-preview",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/docs-preview/package.json
+++ b/docs-preview/package.json
@@ -2,7 +2,7 @@
   "name": "docs-preview",
   "displayName": "docs-preview",
   "description": "Docs Markdown Preview Extension",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "publisher": "docsmsft",
   "icon": "images/docs-logo-ms.png",
   "bugs": {
@@ -14,7 +14,7 @@
     "url": "https://github.com/Microsoft/vscode-docs-authoring.git"
   },
   "engines": {
-    "vscode": "^1.18.x"
+    "vscode": "^1.23.0"
   },
   "categories": [
     "Snippets",

--- a/docs-preview/src/extension.ts
+++ b/docs-preview/src/extension.ts
@@ -42,10 +42,12 @@ export async function activate(context: ExtensionContext) {
     const registration = workspace.registerTextDocumentContentProvider(DocumentContentProvider.scheme, provider);
 
     const disposableSidePreview = commands.registerCommand("docs.showPreviewToSide", (uri) => {
-        preview(uri, ViewColumn.Two, provider);
+        // preview(uri, ViewColumn.Two, provider);
+        commands.executeCommand("markdown.showPreviewToSide");
     });
     const disposableStandalonePreview = commands.registerCommand("docs.showPreview", (uri) => {
-        preview(uri, ViewColumn.One, provider);
+        // preview(uri, ViewColumn.One, provider);
+        commands.executeCommand("markdown.showPreview");
     });
     const disposableDidClick = commands.registerCommand("docs.didClick", (uri, line) => {
         click(uri, line);

--- a/docs-preview/src/extension.ts
+++ b/docs-preview/src/extension.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { commands, ExtensionContext, extensions, OutputChannel, Position, Range, Selection, TextEditorRevealType, Uri, ViewColumn, window, workspace } from "vscode";
+import { commands, ExtensionContext, extensions, OutputChannel, Position, Range, Selection, TextEditorRevealType, Uri, window, workspace } from "vscode";
 import { DocumentContentProvider, isMarkdownFile } from "./provider";
 import { MarkdocsServer } from "./server";
 import * as util from "./util/common";
@@ -28,12 +28,12 @@ export async function activate(context: ExtensionContext) {
     const registration = workspace.registerTextDocumentContentProvider(DocumentContentProvider.scheme, provider);
 
     const disposableSidePreview = commands.registerCommand("docs.showPreviewToSide", (uri) => {
-        preview(uri, ViewColumn.Two, provider);
-        // commands.executeCommand("markdown.showPreviewToSide");
+        // preview(uri, ViewColumn.Two, provider);
+        commands.executeCommand("markdown.showPreviewToSide");
     });
     const disposableStandalonePreview = commands.registerCommand("docs.showPreview", (uri) => {
-        preview(uri, ViewColumn.One, provider);
-        // commands.executeCommand("markdown.showPreview");
+        // preview(uri, ViewColumn.One, provider);
+        commands.executeCommand("markdown.showPreview");
     });
     const disposableDidClick = commands.registerCommand("docs.didClick", (uri, line) => {
         click(uri, line);

--- a/docs-preview/src/extension.ts
+++ b/docs-preview/src/extension.ts
@@ -1,19 +1,5 @@
 import * as path from "path";
-import {
-    commands,
-    Extension,
-    ExtensionContext,
-    extensions,
-    OutputChannel,
-    Position,
-    Range,
-    Selection,
-    TextEditorRevealType,
-    Uri,
-    ViewColumn,
-    window,
-    workspace,
-} from "vscode";
+import { commands, ExtensionContext, extensions, OutputChannel, Position, Range, Selection, TextEditorRevealType, Uri, ViewColumn, window, workspace } from "vscode";
 import { DocumentContentProvider, isMarkdownFile } from "./provider";
 import { MarkdocsServer } from "./server";
 import * as util from "./util/common";
@@ -42,12 +28,12 @@ export async function activate(context: ExtensionContext) {
     const registration = workspace.registerTextDocumentContentProvider(DocumentContentProvider.scheme, provider);
 
     const disposableSidePreview = commands.registerCommand("docs.showPreviewToSide", (uri) => {
-        // preview(uri, ViewColumn.Two, provider);
-        commands.executeCommand("markdown.showPreviewToSide");
+        preview(uri, ViewColumn.Two, provider);
+        // commands.executeCommand("markdown.showPreviewToSide");
     });
     const disposableStandalonePreview = commands.registerCommand("docs.showPreview", (uri) => {
-        // preview(uri, ViewColumn.One, provider);
-        commands.executeCommand("markdown.showPreview");
+        preview(uri, ViewColumn.One, provider);
+        // commands.executeCommand("markdown.showPreview");
     });
     const disposableDidClick = commands.registerCommand("docs.didClick", (uri, line) => {
         click(uri, line);


### PR DESCRIPTION
1. Add vscode settings to enable local debugging
2. Update vscode version
3. Add changelog and update readme
4. Update extension.ts to use VSCode preview instead of docs-preview environment