### PR TITLE
Remove unnecessary links in readme

### DIFF
--- a/docs-yaml/CHANGELOG.md
+++ b/docs-yaml/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## **0.2.3**
+
+- Remove links in readme
+
 ## **0.2.2**
 
 - Gather basic usage data

--- a/docs-yaml/README.md
+++ b/docs-yaml/README.md
@@ -1,10 +1,6 @@
 [![Build status](https://ceapex.visualstudio.com/Engineering/_apis/build/status/Authoring/docs-yaml%20CI)](https://ceapex.visualstudio.com/Engineering/_build/latest?definitionId=1358&branchName=develop)
 # Docs YAML Extension
 
-[![Current-Version](https://vsmarketplacebadge.apphb.com/version/docsmsft.docs-yaml.svg)](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-yaml)
-[![Install-Count](https://vsmarketplacebadge.apphb.com/installs/docsmsft.docs-yaml.svg)](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-yaml)
-[![Open-Issues](https://vsmarketplacebadge.apphb.com/rating/docsmsft.docs-yaml.svg)](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-yaml)
-
 Provides Docs YAML support via [yaml-language-server](https://github.com/redhat-developer/yaml-language-server).
 
 ## Schemas supported to validate

--- a/docs-yaml/package-lock.json
+++ b/docs-yaml/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "docs-yaml",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/docs-yaml/package.json
+++ b/docs-yaml/package.json
@@ -3,7 +3,7 @@
     "displayName": "docs-yaml",
     "description": "YAML schema validation and auto-completion for docs.microsoft.com authoring",
     "aiKey": "85ed760d-c958-4bc2-bd1e-fb7e1e0b9ef8",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "publisher": "docsmsft",
     "engines": {
         "vscode": "^1.25.0"


### PR DESCRIPTION
Removing broken links in readme that are unnecessary because the information is already available on the [marketplace](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-yaml).

![image](https://user-images.githubusercontent.com/11825888/57797938-6766b380-7700-11e9-8c04-eb67307f0d61.png)
