### PR TITLE
Support custom tab values in lists

### DIFF
--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.2.6 (TBD)
+
+- Build reporting link
+- UI updates
+- Support custom tabbing in lists
+
 ## 0.2.5 (April 26th, 2019)
 
 - Telemetry: basic usage data

--- a/docs-markdown/package-lock.json
+++ b/docs-markdown/package-lock.json
@@ -1441,6 +1441,11 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "detect-indent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
+      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA=="
+    },
     "detect-newline": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
@@ -1932,7 +1937,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1953,12 +1959,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1973,17 +1981,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2100,7 +2111,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2112,6 +2124,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2126,6 +2139,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2133,12 +2147,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2157,6 +2173,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2237,7 +2254,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2249,6 +2267,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2334,7 +2353,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2370,6 +2390,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2389,6 +2410,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2432,12 +2454,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/docs-markdown/package-lock.json
+++ b/docs-markdown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-markdown",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -310,6 +310,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "detect-indent": "^6.0.0",
     "diff": "^4.0.1",
     "file-exists": "^5.0.1",
     "fs-exists-sync": "^0.1.0",

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "85ed760d-c958-4bc2-bd1e-fb7e1e0b9ef8",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {
@@ -236,6 +236,11 @@
           "default": false,
           "description": "Show the legacy toolbar in the bottom status bar.",
           "scope": "window"
+        },
+        "markdown.ignoreUnsupportedIndent": {
+          "type": "boolean",
+          "default": false,
+          "description": "Used for custom tabbing support."
         }
       }
     },

--- a/docs-markdown/src/controllers/list-controller.ts
+++ b/docs-markdown/src/controllers/list-controller.ts
@@ -1,13 +1,13 @@
 "use strict";
 
-import { Range, window, workspace } from "vscode";
+import { Range, window } from "vscode";
 import { ListType } from "../constants/list-type";
 import { output } from "../extension";
-import { insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage, postWarning, showStatusMessage } from "../helper/common";
+import { insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage } from "../helper/common";
 import {
     addIndent, autolistAlpha, autolistNumbered, checkEmptyLine, checkEmptySelection, CountIndent, createBulletedListFromText, createNumberedListFromText,
-    fixedBulletedListRegex, fixedNumberedListWithIndentRegexTemplate, getAlphabetLine, getNumberedLine, getNumberedLineWithRegex, insertList, isBulletedLine,
-    nestedNumberedList, removeNestedListMultipleLine, removeNestedListSingleLine, tabPattern, evaluateIndent,
+    evaluateIndent, fixedBulletedListRegex, fixedNumberedListWithIndentRegexTemplate, getAlphabetLine, getNumberedLine, getNumberedLineWithRegex,
+    isBulletedLine, nestedNumberedList, removeNestedListMultipleLine, removeNestedListSingleLine, tabPattern,
 } from "../helper/list";
 import { reporter } from "../helper/telemetry";
 

--- a/docs-markdown/src/controllers/list-controller.ts
+++ b/docs-markdown/src/controllers/list-controller.ts
@@ -7,7 +7,7 @@ import { insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEdit
 import {
     addIndent, autolistAlpha, autolistNumbered, checkEmptyLine, checkEmptySelection, CountIndent, createBulletedListFromText, createNumberedListFromText,
     fixedBulletedListRegex, fixedNumberedListWithIndentRegexTemplate, getAlphabetLine, getNumberedLine, getNumberedLineWithRegex, insertList, isBulletedLine,
-    nestedNumberedList, removeNestedListMultipleLine, removeNestedListSingleLine, tabPattern,
+    nestedNumberedList, removeNestedListMultipleLine, removeNestedListSingleLine, tabPattern, evaluateIndent,
 } from "../helper/list";
 import { reporter } from "../helper/telemetry";
 
@@ -29,9 +29,6 @@ export function insertListsCommands() {
  */
 export function insertNumberedList() {
     reporter.sendTelemetryEvent(`${telemetryCommand}.numbered`);
-    const indent = getIndentationValue();
-    indentationMessage();
-
     const editor = window.activeTextEditor;
     if (!editor) {
         noActiveEditorMessage();
@@ -46,7 +43,7 @@ export function insertNumberedList() {
         }
 
         if (checkEmptyLine(editor) || checkEmptySelection(editor)) {
-            insertList(editor, ListType.Numbered);
+            evaluateIndent(editor, ListType.Numbered);
         } else {
             createNumberedListFromText(editor);
         }
@@ -74,7 +71,7 @@ export function insertBulletedList() {
 
         try {
             if (checkEmptyLine(editor)) {
-                insertList(editor, ListType.Bulleted);
+                evaluateIndent(editor, ListType.Bulleted);
             } else {
                 createBulletedListFromText(editor);
             }
@@ -222,18 +219,5 @@ export function removeNestedList() {
         } else {
             removeNestedListSingleLine(editor);
         }
-    }
-}
-
-export function getIndentationValue() {
-    return workspace.getConfiguration().get("editor.tabSize");
-}
-
-export function indentationMessage() {
-    const indent = getIndentationValue();
-    if (workspace.getConfiguration("markdown").ignoreUnsupportedIndent) {
-        showStatusMessage(`The editor.tabSize value ${indent} is not supported for publishing to docs.microsoft.com. List tabbing will default to 4 spaces when using the Docs Markdown extension.`);
-    } else {
-        postWarning(`The editor.tabSize value ${indent} is not supported for publishing to docs.microsoft.com. List tabbing will default to 4 spaces when using the Docs Markdown extension.`)
     }
 }

--- a/docs-markdown/src/helper/list.ts
+++ b/docs-markdown/src/helper/list.ts
@@ -38,7 +38,7 @@ export function getTabSize() {
  * Determine if user indent value is supported for OPS rendering.
  * If the value is anything other than 4, the user should be notified (4 is the supported value).
  */
-export async function evaluateIndent(editor: vscode.TextEditor, listType: ListType) {
+export function evaluateIndent(editor: vscode.TextEditor, listType: ListType) {
     editorTabSize = getTabSize();
     if (editorTabSize === 4) {
         createIndent(4);
@@ -88,7 +88,7 @@ export function indentationMessage(editor: vscode.TextEditor, listType: ListType
     }
 }
 
-export async function createIndent(indent: any) {
+export function createIndent(indent: any) {
     const singleSpace = " ";
     // create tab value based on users vscode setting
     tabPattern = singleSpace.repeat(indent);
@@ -97,7 +97,7 @@ export async function createIndent(indent: any) {
 /**
  * Creates a list(numbered or bulleted) in the vscode editor.
  */
-export async function insertList(editor: vscode.TextEditor, listType: ListType) {
+export function insertList(editor: vscode.TextEditor, listType: ListType) {
     const cursorPosition = editor.selection.active;
     const lineText = editor.document.lineAt(cursorPosition.line).text;
     const listObjectModel = createListObjectModel(editor);

--- a/docs-markdown/src/helper/list.ts
+++ b/docs-markdown/src/helper/list.ts
@@ -22,10 +22,9 @@ export const fixedNumberedListWithIndentRegexTemplate = "^( ){{0}}[0-9]+\\.( )$"
 export const fixedAlphabetListWithIndentRegexTemplate = "^( ){{0}}[a-z]{1}\\.( )$";
 export const startAlphabet = "a";
 export const numberedListValue = "1";
-export let indentSpacing: any;
-export const singleSpace = " ";
 export let tabPattern: any;
 export let editorTabSize: any;
+// used to supress prompt for unsupported tab size for a given session.
 export let hideMessage: boolean = false;
 
 /**
@@ -57,7 +56,7 @@ export function indentationMessage(editor: vscode.TextEditor, listType: ListType
     const ignorePermanently = "Ignore permanently and use editor.tabSize value.";
     // check for markdown.ignoreUnsupportedIndent setting. if setting is true, use custom indent and add message to output window.
     if (vscode.workspace.getConfiguration("markdown").ignoreUnsupportedIndent) {
-        createIndent(indentSpacing);
+        createIndent(editorTabSize);
         insertList(editor, listType);
         common.showStatusMessage(`The editor.tabSize value ${editorTabSize} is not supported for publishing to docs.microsoft.com.`);
     }
@@ -71,13 +70,17 @@ export function indentationMessage(editor: vscode.TextEditor, listType: ListType
             switch (result) {
                 case dismiss: {
                     hideMessage = true;
+                    // default to 4 spaces
                     createIndent(4);
                     insertList(editor, listType);
                     break;
                 }
                 case ignorePermanently: {
-                    createIndent(indentSpacing);
+                    // use tabSize settings value
+                    createIndent(editorTabSize);
                     insertList(editor, listType);
+                    // add property to settings.json
+                    vscode.workspace.getConfiguration().update("markdown.ignoreUnsupportedIndent", true, vscode.ConfigurationTarget.Global);
                     break;
                 }
             }
@@ -86,6 +89,7 @@ export function indentationMessage(editor: vscode.TextEditor, listType: ListType
 }
 
 export async function createIndent(indent: any) {
+    const singleSpace = " ";
     // create tab value based on users vscode setting
     tabPattern = singleSpace.repeat(indent);
 }


### PR DESCRIPTION
Support custom tab sizes in lists.  Extension does not check for tabSize settings and defaults to 4 spaces.  This PR will check for editor.tabSize setting and allow the user to either use that value or continue to use the supported 4 space pattern.

**List-controller.ts**
1. Named imports
2. Instead of calling insertList function, it now calls evaluateIndent

**Lists.ts**
1. getTabSize function: Checks for the editor.tabSize setting and returns the value
2. evaluateIndent function: Checks to see if editor.tabSize value is supported.  If not, calls indentationMessage function to notify the user.
3. indentationMessage function: Notify the user if tab size is unsupported and provide an option to use default value or unsupported custom value.  
4. createIndent function: Create the tabPattern (spaces) based on the tabSize setting.
