### PR TITLE
Support custom tab sizes in lists

### DIFF
--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.8 (TBD)
+
+- Support custom tabbing in lists
+
 ## 0.2.7 (June 7th, 2019)
 
 - Telemetry update

--- a/docs-markdown/package-lock.json
+++ b/docs-markdown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-markdown",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {
@@ -236,6 +236,11 @@
           "default": false,
           "description": "Show the legacy toolbar in the bottom status bar.",
           "scope": "window"
+        },
+        "markdown.ignoreUnsupportedIndent": {
+          "type": "boolean",
+          "default": false,
+          "description": "Used for custom tabbing support."
         }
       }
     },

--- a/docs-markdown/src/controllers/list-controller.ts
+++ b/docs-markdown/src/controllers/list-controller.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 import { ListType } from "../constants/list-type";
 import { output } from "../extension";
 import { insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage, sendTelemetryData } from "../helper/common";
-import { addIndent, autolistAlpha, autolistNumbered, checkEmptyLine, checkEmptySelection, CountIndent, createBulletedListFromText, createNumberedListFromText, fixedBulletedListRegex, fixedNumberedListWithIndentRegexTemplate, getAlphabetLine, getNumberedLine, getNumberedLineWithRegex, insertList, isBulletedLine, nestedNumberedList, removeNestedListMultipleLine, removeNestedListSingleLine, tabPattern } from "../helper/list";
+import { addIndent, autolistAlpha, autolistNumbered, checkEmptyLine, checkEmptySelection, CountIndent, createBulletedListFromText, createNumberedListFromText, evaluateIndent, fixedBulletedListRegex, fixedNumberedListWithIndentRegexTemplate, getAlphabetLine, getNumberedLine, getNumberedLineWithRegex, isBulletedLine, nestedNumberedList, removeNestedListMultipleLine, removeNestedListSingleLine, tabPattern } from "../helper/list";
 
 const telemetryCommand: string = "insertList";
 let commandOption: string;
@@ -39,7 +39,7 @@ export function insertNumberedList() {
         }
 
         if (checkEmptyLine(editor) || checkEmptySelection(editor)) {
-            insertList(editor, ListType.Numbered);
+            evaluateIndent(editor, ListType.Numbered);
         } else {
             createNumberedListFromText(editor);
         }
@@ -67,7 +67,7 @@ export function insertBulletedList() {
 
         try {
             if (checkEmptyLine(editor)) {
-                insertList(editor, ListType.Bulleted);
+                evaluateIndent(editor, ListType.Bulleted);
             } else {
                 createBulletedListFromText(editor);
             }

--- a/docs-markdown/src/helper/list.ts
+++ b/docs-markdown/src/helper/list.ts
@@ -20,9 +20,79 @@ export const alphabetListWithIndentRegexTemplate = "^( ){{0}}[a-z]{1}\\.( )";
 export const fixedBulletedListRegex = /^( )*\-( )$/;
 export const fixedNumberedListWithIndentRegexTemplate = "^( ){{0}}[0-9]+\\.( )$";
 export const fixedAlphabetListWithIndentRegexTemplate = "^( ){{0}}[a-z]{1}\\.( )$";
-export const tabPattern = "    ";
 export const startAlphabet = "a";
 export const numberedListValue = "1";
+export let tabPattern: any;
+export let editorTabSize: any;
+// used to supress prompt for unsupported tab size for a given session.
+export let hideMessage: boolean = false;
+
+/**
+ * Get editor.tabSize value from settings
+ */
+export function getTabSize() {
+    return vscode.workspace.getConfiguration().get("editor.tabSize");
+}
+
+/**
+ * Determine if user indent value is supported for OPS rendering.
+ * If the value is anything other than 4, the user should be notified (4 is the supported value).
+ */
+export function evaluateIndent(editor: vscode.TextEditor, listType: ListType) {
+    editorTabSize = getTabSize();
+    if (editorTabSize === 4) {
+        createIndent(4);
+        insertList(editor, listType);
+    } else {
+        indentationMessage(editor, listType);
+    }
+}
+
+/**
+ * Message users if indent value is unsupported.
+ */
+export function indentationMessage(editor: vscode.TextEditor, listType: ListType) {
+    const dismiss = "Use 4 spaces.";
+    const ignorePermanently = "Ignore permanently and use editor.tabSize value.";
+    // check for markdown.ignoreUnsupportedIndent setting. if setting is true, use custom indent and add message to output window.
+    if (vscode.workspace.getConfiguration("markdown").ignoreUnsupportedIndent) {
+        createIndent(editorTabSize);
+        insertList(editor, listType);
+        common.showStatusMessage(`The editor.tabSize value ${editorTabSize} is not supported for publishing to docs.microsoft.com.`);
+    }
+    if (hideMessage) {
+        createIndent(4);
+        insertList(editor, listType);
+    }
+    if (!vscode.workspace.getConfiguration("markdown").ignoreUnsupportedIndent && !hideMessage) {
+        // if the markdown.ignoreUnsupportedIndent setting is missing or false, allow user to either dismiss or permanently ignore the message.
+        vscode.window.showInformationMessage(`The editor.tabSize value ${editorTabSize} is not supported for publishing to docs.microsoft.com. List tabbing will default to 4 spaces when using the Docs Markdown extension.`, dismiss, ignorePermanently).then((result) => {
+            switch (result) {
+                case dismiss: {
+                    hideMessage = true;
+                    // default to 4 spaces
+                    createIndent(4);
+                    insertList(editor, listType);
+                    break;
+                }
+                case ignorePermanently: {
+                    // use tabSize settings value
+                    createIndent(editorTabSize);
+                    insertList(editor, listType);
+                    // add property to settings.json
+                    vscode.workspace.getConfiguration().update("markdown.ignoreUnsupportedIndent", true, vscode.ConfigurationTarget.Global);
+                    break;
+                }
+            }
+        });
+    }
+}
+
+export function createIndent(indent: any) {
+    const singleSpace = " ";
+    // create tab value based on users vscode setting
+    tabPattern = singleSpace.repeat(indent);
+}
 
 /**
  * Creates a list(numbered or bulleted) in the vscode editor.


### PR DESCRIPTION
Support custom tab sizes in lists. Extension does not check for tabSize settings and defaults to 4 spaces. This PR will check for editor.tabSize setting and allow the user to either use that value or continue to use the supported 4 space pattern.

**List-controller.ts**

1. Instead of calling insertList function, it now calls evaluateIndent

**Lists.ts**

1. getTabSize function: Checks for the editor.tabSize setting and returns the value
2. evaluateIndent function: Checks to see if editor.tabSize value is supported. If not, calls indentationMessage function to notify the user.
3. indentationMessage function: Notify the user if tab size is unsupported and provide an option to use default value or unsupported custom value.
4. createIndent function: Create the tabPattern (spaces) based on the tabSize setting.