### PR TITLE
Remove custom tabbing support

### DIFF
--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.9 (June 14th, 2019)
+
+- Breaking change in latest VS Code release: revert custom tabbing support
+
 ## 0.2.8 (June 11th, 2019)
 
 - Support custom tabbing in lists

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {
@@ -236,11 +236,6 @@
           "default": false,
           "description": "Show the legacy toolbar in the bottom status bar.",
           "scope": "window"
-        },
-        "markdown.ignoreUnsupportedIndent": {
-          "type": "boolean",
-          "default": false,
-          "description": "Used for custom tabbing support."
         }
       }
     },

--- a/docs-markdown/src/controllers/list-controller.ts
+++ b/docs-markdown/src/controllers/list-controller.ts
@@ -4,7 +4,7 @@ import * as vscode from "vscode";
 import { ListType } from "../constants/list-type";
 import { output } from "../extension";
 import { insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage, sendTelemetryData } from "../helper/common";
-import { addIndent, autolistAlpha, autolistNumbered, checkEmptyLine, checkEmptySelection, CountIndent, createBulletedListFromText, createNumberedListFromText, evaluateIndent, fixedBulletedListRegex, fixedNumberedListWithIndentRegexTemplate, getAlphabetLine, getNumberedLine, getNumberedLineWithRegex, isBulletedLine, nestedNumberedList, removeNestedListMultipleLine, removeNestedListSingleLine, tabPattern } from "../helper/list";
+import { addIndent, autolistAlpha, autolistNumbered, checkEmptyLine, checkEmptySelection, CountIndent, createBulletedListFromText, createNumberedListFromText, fixedBulletedListRegex, fixedNumberedListWithIndentRegexTemplate, getAlphabetLine, getNumberedLine, getNumberedLineWithRegex, insertList, isBulletedLine, nestedNumberedList, removeNestedListMultipleLine, removeNestedListSingleLine, tabPattern } from "../helper/list";
 
 const telemetryCommand: string = "insertList";
 let commandOption: string;
@@ -39,7 +39,7 @@ export function insertNumberedList() {
         }
 
         if (checkEmptyLine(editor) || checkEmptySelection(editor)) {
-            evaluateIndent(editor, ListType.Numbered);
+            insertList(editor, ListType.Numbered);
         } else {
             createNumberedListFromText(editor);
         }
@@ -67,7 +67,7 @@ export function insertBulletedList() {
 
         try {
             if (checkEmptyLine(editor)) {
-                evaluateIndent(editor, ListType.Bulleted);
+                insertList(editor, ListType.Bulleted);
             } else {
                 createBulletedListFromText(editor);
             }

--- a/docs-markdown/src/helper/list.ts
+++ b/docs-markdown/src/helper/list.ts
@@ -22,77 +22,7 @@ export const fixedNumberedListWithIndentRegexTemplate = "^( ){{0}}[0-9]+\\.( )$"
 export const fixedAlphabetListWithIndentRegexTemplate = "^( ){{0}}[a-z]{1}\\.( )$";
 export const startAlphabet = "a";
 export const numberedListValue = "1";
-export let tabPattern: any;
-export let editorTabSize: any;
-// used to supress prompt for unsupported tab size for a given session.
-export let hideMessage: boolean = false;
-
-/**
- * Get editor.tabSize value from settings
- */
-export function getTabSize() {
-    return vscode.workspace.getConfiguration().get("editor.tabSize");
-}
-
-/**
- * Determine if user indent value is supported for OPS rendering.
- * If the value is anything other than 4, the user should be notified (4 is the supported value).
- */
-export function evaluateIndent(editor: vscode.TextEditor, listType: ListType) {
-    editorTabSize = getTabSize();
-    if (editorTabSize === 4) {
-        createIndent(4);
-        insertList(editor, listType);
-    } else {
-        indentationMessage(editor, listType);
-    }
-}
-
-/**
- * Message users if indent value is unsupported.
- */
-export function indentationMessage(editor: vscode.TextEditor, listType: ListType) {
-    const dismiss = "Use 4 spaces.";
-    const ignorePermanently = "Ignore permanently and use editor.tabSize value.";
-    // check for markdown.ignoreUnsupportedIndent setting. if setting is true, use custom indent and add message to output window.
-    if (vscode.workspace.getConfiguration("markdown").ignoreUnsupportedIndent) {
-        createIndent(editorTabSize);
-        insertList(editor, listType);
-        common.showStatusMessage(`The editor.tabSize value ${editorTabSize} is not supported for publishing to docs.microsoft.com.`);
-    }
-    if (hideMessage) {
-        createIndent(4);
-        insertList(editor, listType);
-    }
-    if (!vscode.workspace.getConfiguration("markdown").ignoreUnsupportedIndent && !hideMessage) {
-        // if the markdown.ignoreUnsupportedIndent setting is missing or false, allow user to either dismiss or permanently ignore the message.
-        vscode.window.showInformationMessage(`The editor.tabSize value ${editorTabSize} is not supported for publishing to docs.microsoft.com. List tabbing will default to 4 spaces when using the Docs Markdown extension.`, dismiss, ignorePermanently).then((result) => {
-            switch (result) {
-                case dismiss: {
-                    hideMessage = true;
-                    // default to 4 spaces
-                    createIndent(4);
-                    insertList(editor, listType);
-                    break;
-                }
-                case ignorePermanently: {
-                    // use tabSize settings value
-                    createIndent(editorTabSize);
-                    insertList(editor, listType);
-                    // add property to settings.json
-                    vscode.workspace.getConfiguration().update("markdown.ignoreUnsupportedIndent", true, vscode.ConfigurationTarget.Global);
-                    break;
-                }
-            }
-        });
-    }
-}
-
-export function createIndent(indent: any) {
-    const singleSpace = " ";
-    // create tab value based on users vscode setting
-    tabPattern = singleSpace.repeat(indent);
-}
+export let tabPattern = "    ";
 
 /**
  * Creates a list(numbered or bulleted) in the vscode editor.


### PR DESCRIPTION
Breaking change in latest VS Code release.  Address this [issue](https://github.com/microsoft/vscode-docs-authoring/issues/232).

1. Remove setting.
2. Update version and changelog.
3. Remove custom setting code.