### PR TITLE
feat(cleanup): Re-write flagged Microsoft links to HTTPS

### DIFF
--- a/docs-markdown/src/controllers/cleanup-controller.ts
+++ b/docs-markdown/src/controllers/cleanup-controller.ts
@@ -534,6 +534,8 @@ function microsoftLinks(workspacePath: string, progress: any, resolve: any) {
  * @param data takes data string as arg
  */
 function handleLinksWithRegex(data: string) {
+    const akaRegex = new RegExp(/http:\/\/aka.ms/g);
+    data = data.replace(akaRegex, "https://aka.ms");
     const docsRegex = new RegExp(/http:\/\/docs.microsoft.com/g);
     data = data.replace(docsRegex, "https://docs.microsoft.com");
     const azureRegex = new RegExp(/http:\/\/azure.microsoft.com/g);

--- a/docs-markdown/src/controllers/cleanup-controller.ts
+++ b/docs-markdown/src/controllers/cleanup-controller.ts
@@ -537,7 +537,9 @@ function handleLinksWithRegex(data: string) {
     const akaRegex = new RegExp(/http:\/\/aka.ms/g);
     data = data.replace(akaRegex, "https://aka.ms");
     const visualstudioRegex = new RegExp(/http:\/\/visualstudio.com/g);
-    data = data.replace(visualstudioRegex, "https://visualstudio.com");
+    data = data.replace(visualstudioRegex, "https://visualstudio.com");;
+    const officeRegex = new RegExp(/http:\/\/office.com/g);
+    data = data.replace(officeRegex, "https://office.com");
     const docsRegex = new RegExp(/http:\/\/docs.microsoft.com/g);
     data = data.replace(docsRegex, "https://docs.microsoft.com");
     const azureRegex = new RegExp(/http:\/\/azure.microsoft.com/g);

--- a/docs-markdown/src/controllers/cleanup-controller.ts
+++ b/docs-markdown/src/controllers/cleanup-controller.ts
@@ -548,6 +548,8 @@ function handleLinksWithRegex(data: string) {
     data = data.replace(azureRegex2, "https://azure.com");
     const msdnRegex = new RegExp(/http:\/\/msdn.microsoft.com/g);
     data = data.replace(msdnRegex, "https://msdn.microsoft.com");
+    const msdnRegex2 = new RegExp(/http:\/\/msdn.com/g);
+    data = data.replace(msdnRegex2, "https://msdn.com");
     const technetRegex = new RegExp(/http:\/\/technet.microsoft.com/g);
     data = data.replace(technetRegex, "https://technet.microsoft.com");
     const docsRegexLang = new RegExp(/https:\/\/docs.microsoft.com\/[A-Za-z]{2}-[A-Za-z]{2}\//g);

--- a/docs-markdown/src/controllers/cleanup-controller.ts
+++ b/docs-markdown/src/controllers/cleanup-controller.ts
@@ -537,13 +537,15 @@ function handleLinksWithRegex(data: string) {
     const akaRegex = new RegExp(/http:\/\/aka.ms/g);
     data = data.replace(akaRegex, "https://aka.ms");
     const visualstudioRegex = new RegExp(/http:\/\/visualstudio.com/g);
-    data = data.replace(visualstudioRegex, "https://visualstudio.com");;
+    data = data.replace(visualstudioRegex, "https://visualstudio.com");
     const officeRegex = new RegExp(/http:\/\/office.com/g);
     data = data.replace(officeRegex, "https://office.com");
     const docsRegex = new RegExp(/http:\/\/docs.microsoft.com/g);
     data = data.replace(docsRegex, "https://docs.microsoft.com");
     const azureRegex = new RegExp(/http:\/\/azure.microsoft.com/g);
     data = data.replace(azureRegex, "https://azure.microsoft.com");
+    const azureRegex2 = new RegExp(/http:\/\/azure.com/g);
+    data = data.replace(azureRegex2, "https://azure.com");
     const msdnRegex = new RegExp(/http:\/\/msdn.microsoft.com/g);
     data = data.replace(msdnRegex, "https://msdn.microsoft.com");
     const technetRegex = new RegExp(/http:\/\/technet.microsoft.com/g);

--- a/docs-markdown/src/controllers/cleanup-controller.ts
+++ b/docs-markdown/src/controllers/cleanup-controller.ts
@@ -536,6 +536,8 @@ function microsoftLinks(workspacePath: string, progress: any, resolve: any) {
 function handleLinksWithRegex(data: string) {
     const akaRegex = new RegExp(/http:\/\/aka.ms/g);
     data = data.replace(akaRegex, "https://aka.ms");
+    const microsoftRegex = new RegExp(/http:\/\/microsoft.com/g);
+    data = data.replace(microsoftRegex, "https://microsoft.com");
     const visualstudioRegex = new RegExp(/http:\/\/visualstudio.com/g);
     data = data.replace(visualstudioRegex, "https://visualstudio.com");
     const officeRegex = new RegExp(/http:\/\/office.com/g);

--- a/docs-markdown/src/controllers/cleanup-controller.ts
+++ b/docs-markdown/src/controllers/cleanup-controller.ts
@@ -536,6 +536,8 @@ function microsoftLinks(workspacePath: string, progress: any, resolve: any) {
 function handleLinksWithRegex(data: string) {
     const akaRegex = new RegExp(/http:\/\/aka.ms/g);
     data = data.replace(akaRegex, "https://aka.ms");
+    const visualstudioRegex = new RegExp(/http:\/\/visualstudio.com/g);
+    data = data.replace(visualstudioRegex, "https://visualstudio.com");
     const docsRegex = new RegExp(/http:\/\/docs.microsoft.com/g);
     data = data.replace(docsRegex, "https://docs.microsoft.com");
     const azureRegex = new RegExp(/http:\/\/azure.microsoft.com/g);


### PR DESCRIPTION
Seems to follow, since you have a markdownlint rule to flag them https://github.com/microsoft/vscode-docs-authoring/blob/22f34877bc93904603faa770be07a462a3e5f173/docs-markdown/markdownlint-custom-rules/common.js#L43