### PR TITLE
Only show preview commands for markdown

### DIFF
--- a/docs-preview/changelog.md
+++ b/docs-preview/changelog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.3.23 (June 25th, 2019)
+
+- Command palette updates
+
+## 0.3.22 (June 18th, 2019)
+
+- Rendering improvements for includes
+
 ## 0.3.21 (June 7th, 2019)
 
 - Telemetry updates

--- a/docs-preview/package-lock.json
+++ b/docs-preview/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-preview",
-  "version": "0.3.21",
+  "version": "0.3.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/docs-preview/package.json
+++ b/docs-preview/package.json
@@ -3,7 +3,7 @@
   "displayName": "docs-preview",
   "description": "Docs Markdown Preview Extension",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "publisher": "docsmsft",
   "icon": "images/docs-logo-ms.png",
   "bugs": {
@@ -28,8 +28,6 @@
     "docfx"
   ],
   "activationEvents": [
-    "onCommand:docs.showPreview",
-    "onCommand:docs.showPreviewToSide",
     "onLanguage:markdown"
   ],
   "main": "./out/src/extension",
@@ -52,7 +50,19 @@
         "title": "Docs: Preview in current tab",
         "when": "editorTextFocus"
       }
-    ]
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "when": "resourceLangId == markdown",
+          "command": "docs.showPreviewToSide"
+        },
+        {
+          "when": "resourceLangId == markdown",
+          "command": "docs.showPreview"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "tsc -p ./",


### PR DESCRIPTION
Add conditions to only show preview commands for markdown files.