### PR TITLE
Docs-article-templates public feedback

### DIFF
--- a/docs-article-templates/CHANGELOG.md
+++ b/docs-article-templates/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.6 (July 5th, 2019)
+
+- Logging improvements
+
 ## 0.2.5 (June 18th, 2019)
 
 - Logging improvements

--- a/docs-article-templates/package-lock.json
+++ b/docs-article-templates/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "docs-article-templates",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1327,6 +1327,15 @@
             "requires": {
                 "http-proxy-agent": "^2.1.0",
                 "https-proxy-agent": "^2.2.1"
+            }
+        },
+        "web-request": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/web-request/-/web-request-1.0.7.tgz",
+            "integrity": "sha1-twxCs81FV3noLbaIYlOySR8r1Wk=",
+            "dev": true,
+            "requires": {
+                "request": "^2.69.0"
             }
         },
         "wrappy": {

--- a/docs-article-templates/package.json
+++ b/docs-article-templates/package.json
@@ -4,7 +4,7 @@
   "description": "Docs article templates",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "publisher": "docsmsft",
   "engines": {
     "vscode": "^1.23.0"
@@ -75,7 +75,8 @@
     "@types/mocha": "^2.2.42",
     "@types/node": "^7.0.43",
     "typescript": "^2.6.1",
-    "vscode": "^1.1.33"
+    "vscode": "^1.1.33",
+    "web-request": "^1.0.7"
   },
   "repository": {
     "type": "git",

--- a/docs-article-templates/src/helper/github.ts
+++ b/docs-article-templates/src/helper/github.ts
@@ -3,8 +3,8 @@
 import { readdir, stat, unlinkSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
+import * as WebRequest from 'web-request';
 import { displayTemplates } from "../controllers/quick-pick-controller";
-import { output } from "../extension";
 import { postWarning, showStatusMessage } from "../helper/common";
 
 export const docsAuthoringDirectory = join(homedir(), "Docs Authoring");
@@ -20,6 +20,7 @@ export async function downloadRepo() {
             showStatusMessage(err ? `Error: Cannot connect to ${templateRepo}` : "Success");
         } else {
             displayTemplates();
+            logRepoData();
         }
     });
 }
@@ -47,4 +48,11 @@ export function cleanupDownloadFiles(templates?: boolean) {
             });
         });
     });
+}
+
+export async function logRepoData() {
+    const repoUrl = `https://github.com/MicrosoftDocs/content-templates`;
+    const result = await WebRequest.get(repoUrl);
+    showStatusMessage(`Content-templates repo URL and http response: ${repoUrl}, ${result.statusCode}`);
+    showStatusMessage(`Local template directory: ${templateDirectory}`);
 }


### PR DESCRIPTION
**User feedback/requests**
1) In the vscode logs, output the url and the http response. 
2) Share the URL where the templates reside so we can trace/troubleshoot. 
3) The ability to download the templates for offline use.

**Updates**

1. Add new function to log repo data (show url, response code and local template directory path).