### PR TITLE
Support for MD025

### DIFF
--- a/docs-markdown/src/controllers/lint-config-controller.ts
+++ b/docs-markdown/src/controllers/lint-config-controller.ts
@@ -1,0 +1,17 @@
+"use strict";
+
+import { ConfigurationTarget, workspace } from "vscode";
+import { showStatusMessage } from "../helper/common";
+
+// store users markdownlint settings on activation
+const markdownlintProperty = "markdownlint.config";
+
+export function addFrontMatterTitle() {
+    const markdownlintData: any = workspace.getConfiguration().inspect(markdownlintProperty);
+    if (markdownlintData.globalValue) {
+        const existingUserSettings = markdownlintData.globalValue;
+        Object.assign(existingUserSettings, { MD025: { "front_matter_title": "" } });
+        workspace.getConfiguration().update(markdownlintProperty, existingUserSettings, ConfigurationTarget.Global);
+        showStatusMessage(`Added front_matter_title property to Markdownlint config setting.`);
+    }
+}

--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -6,17 +6,18 @@
  Logging, Error Handling, VS Code window updates, etc.
 */
 
-import { commands, ConfigurationTarget, ExtensionContext, window, workspace, languages, CompletionItem, TextDocument, Position } from "vscode";
+import { commands, CompletionItem, ConfigurationTarget, ExtensionContext, languages, Position, TextDocument, window, workspace } from "vscode";
 import { insertAlertCommand } from "./controllers/alert-controller";
 import { boldFormattingCommand } from "./controllers/bold-controller";
 import { applyCleanupCommand } from "./controllers/cleanup-controller";
 import { codeFormattingCommand } from "./controllers/code-controller";
 import { insertIncludeCommand } from "./controllers/include-controller";
 import { italicFormattingCommand } from "./controllers/italic-controller";
+import { addFrontMatterTitle } from "./controllers/lint-config-controller";
 import { insertListsCommands } from "./controllers/list-controller";
 import { getMasterRedirectionCommand } from "./controllers/master-redirect-controller";
 import { insertLinksAndMediaCommands } from "./controllers/media-controller";
-import { noLocTextCommand, noLocCompletionItemsMarkdownYamlHeader, noLocCompletionItemsMarkdown, noLocCompletionItemsYaml } from "./controllers/no-loc-controller";
+import { noLocCompletionItemsMarkdown, noLocCompletionItemsMarkdownYamlHeader, noLocCompletionItemsYaml, noLocTextCommand } from "./controllers/no-loc-controller";
 import { previewTopicCommand } from "./controllers/preview-controller";
 import { quickPickMenuCommand } from "./controllers/quick-pick-menu-controller";
 import { insertSnippetCommand } from "./controllers/snippet-controller";
@@ -53,6 +54,9 @@ export function activate(context: ExtensionContext) {
 
     // Markdownlint custom rule check
     checkMarkdownlintCustomProperty();
+
+    // Update markdownlint.config to fix MD025 issue
+    addFrontMatterTitle();
 
     // Creates an array of commands from each command file.
     const AuthoringCommands: any = [];


### PR DESCRIPTION
Adding [front matter support](https://github.com/DavidAnson/markdownlint/blob/6f7c0aac131f21dd41a2a26810779c993521b733/test/hugo-quickstart-example-clean.json) to work with Markdownlint MD025 rule update.
