### PR TITLE
Update optional TOC attributes

### DIFF
--- a/docs-markdown/README.md
+++ b/docs-markdown/README.md
@@ -107,6 +107,7 @@ Cleanup scripts available:
 
 - [YAML TOC entries] The Docs-YAML schema validation falsely shows a "Matches a schema that is not allowed" linting error on optional attributes such as `displayName`. These entries are in fact valid, and we'll be updating the schema linting in an upcoming release.
 - [YAML TOC entries] Depending on your settings related to spacing, sometimes attributes in nested TOC entries don't line up correctly. If you experience this issue, make sure all the attributes line up with the nested `name` attribute. A fix is in progress for this bug.
+- [YAML TOC entries] Erroneous invalid location error when trying to add new top level entry after nested entry. A fix is in progress for this bug.
 - [Docs Preview] Code blocks only preview in Dark theme, and some colorized text is unreadable in Light theme.
 - [External bookmarks] Linux: File list is displayed but no headings are shown to select.
 - [Includes] Linux: File list is displayed but no link is added after selection is made.

--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.12 (July 22nd, 2019)
+
+- Update YAML TOC attributes
+
 ## 0.2.11 (July 17th, 2019)
 
 - Markdownlint: Rule MD025 front matter update

--- a/docs-markdown/package-lock.json
+++ b/docs-markdown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-markdown",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {

--- a/docs-markdown/src/controllers/yaml-controller.ts
+++ b/docs-markdown/src/controllers/yaml-controller.ts
@@ -120,10 +120,9 @@ export function createEntry(name: string, href: string, options: boolean) {
     `- name: ${name}
   displayname: #optional string for searching TOC
   href: ${href}
-  maintainContext: #true or false, false is default
   uid: #optional string
-  expanded: #true or false, false is default
-  items: #optional sub-entries`
+  expanded: #true or false, false is default`;
+
 
   const tocEntryWithOptionsIndented =
     `- name: ${name}


### PR DESCRIPTION
1. Removing maintainContext and items attributes from `TOC entry with optional attributes` command.
2. Bump version, changelog and update readme.