### PR TITLE
TOC href target in different directory

### DIFF
--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.2.16 (TBD)
+
+- TOC href link bugfix
+- Telemetry updates
+
 ## 0.2.15 (August 22st, 2019)
 
 - Xref Bug Fixes and support additional Xref tags.

--- a/docs-markdown/src/controllers/yaml-controller.ts
+++ b/docs-markdown/src/controllers/yaml-controller.ts
@@ -2,7 +2,7 @@
 
 import { readFileSync } from "fs";
 import { files } from "node-dir";
-import { basename, dirname, extname, join } from "path";
+import { basename, dirname, extname, join, relative } from "path";
 import { QuickPickItem, window, workspace } from "vscode";
 import { insertedTocEntry, invalidTocEntryPosition, noHeading, noHeadingSelected } from "../constants/log-messages";
 import { insertContentToEditor, noActiveEditorMessage, sendTelemetryData, showStatusMessage } from "../helper/common";
@@ -82,7 +82,9 @@ export function showQuickPick(options: boolean) {
         return;
       }
       let headingName = headings.toString().replace("# ", "");
-      const hrefName = qpSelection.label;
+      const activeFilePath = editor.document.fileName;
+      const href = relative(activeFilePath, fullPath);
+      const formattedHrefPath = href.replace(/\.\.\\/g, "").replace(/\\/g, "/");
       window.showInputBox({
         value: headingName,
         valueSelection: [0, 0],
@@ -93,7 +95,7 @@ export function showQuickPick(options: boolean) {
         if (val) {
           headingName = val;
         }
-        createEntry(headingName, hrefName, options);
+        createEntry(headingName, formattedHrefPath, options);
       });
     });
   });

--- a/docs-markdown/src/controllers/yaml-controller.ts
+++ b/docs-markdown/src/controllers/yaml-controller.ts
@@ -84,7 +84,7 @@ export function showQuickPick(options: boolean) {
       let headingName = headings.toString().replace("# ", "");
       const activeFilePath = editor.document.fileName;
       const href = relative(activeFilePath, fullPath);
-      const formattedHrefPath = href.replace(/\.\.\\/g, "").replace(/\\/g, "/");
+      const formattedHrefPath = href.replace("..\\", "").replace("../", "").replace(/\\/g, "/");
       window.showInputBox({
         value: headingName,
         valueSelection: [0, 0],

--- a/docs-markdown/src/controllers/yaml-controller.ts
+++ b/docs-markdown/src/controllers/yaml-controller.ts
@@ -84,6 +84,7 @@ export function showQuickPick(options: boolean) {
       let headingName = headings.toString().replace("# ", "");
       const activeFilePath = editor.document.fileName;
       const href = relative(activeFilePath, fullPath);
+      // format href: remove addtional leading segment (support windows, macos and linux), set path separators to standard
       const formattedHrefPath = href.replace("..\\", "").replace("../", "").replace(/\\/g, "/");
       window.showInputBox({
         value: headingName,


### PR DESCRIPTION
1. Get the toc.yml file path and determine the relative file path to the selected href topic.
2. Format href path and add to TOC instead of using selected file name.