### PR TITLE
Fix nested toc attribute line-up error

### DIFF
--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,8 +1,9 @@
 # Change Log
 
-## 0.2.16 (TBD)
+## 0.2.16 (September 6th, 2019)
 
 - TOC href link bugfix
+- TOC attribute bugfix
 - Telemetry updates
 
 ## 0.2.15 (August 22st, 2019)

--- a/docs-markdown/src/controllers/yaml-controller.ts
+++ b/docs-markdown/src/controllers/yaml-controller.ts
@@ -109,41 +109,41 @@ export function createEntry(name: string, href: string, options: boolean) {
   }
   const position = editor.selection.active;
   const cursorPosition = position.character;
-  const attributeSpace = "  ";
+  const attributeSpace = " ";
 
-  const tocEntryLineStart =
-    `- name: ${name}
+  if (cursorPosition === 0 && !options) {
+    const tocEntryLineStart =
+      `- name: ${name}
   href: ${href}`
+    insertContentToEditor(editor, insertTocEntry.name, tocEntryLineStart);
+  }
 
-  const tocEntryIndented =
-    `- name: ${name}
-  ${attributeSpace}href: ${href}`
+  if (cursorPosition > 0 && !options) {
+    const currentPosition = editor.selection.active.character;
+    const tocEntryIndented =
+      `- name: ${name}
+  ${attributeSpace.repeat(currentPosition)}href: ${href}`
+    insertContentToEditor(editor, insertTocEntry.name, tocEntryIndented);
+  }
 
-  const tocEntryWithOptions =
-    `- name: ${name}
+  if (cursorPosition === 0 && options) {
+    const tocEntryWithOptions =
+      `- name: ${name}
   displayname: #optional string for searching TOC
   href: ${href}
   uid: #optional string
   expanded: #true or false, false is default`;
-
-
-  const tocEntryWithOptionsIndented =
-    `- name: ${name}
-  ${attributeSpace}displayname: #optional string for searching TOC
-  ${attributeSpace}href: ${href}
-  ${attributeSpace}uid: #optional string
-  ${attributeSpace}expanded: #true or false, false is default`;
-
-  if (cursorPosition === 0 && !options) {
-    insertContentToEditor(editor, insertTocEntry.name, tocEntryLineStart);
-  }
-  if (cursorPosition > 0 && !options) {
-    insertContentToEditor(editor, insertTocEntry.name, tocEntryIndented);
-  }
-  if (cursorPosition === 0 && options) {
     insertContentToEditor(editor, insertTocEntryWithOptions.name, tocEntryWithOptions);
   }
+
   if (cursorPosition > 0 && options) {
+    const currentPosition = editor.selection.active.character;
+    const tocEntryWithOptionsIndented =
+      `- name: ${name}
+  ${attributeSpace.repeat(currentPosition)}displayname: #optional string for searching TOC
+  ${attributeSpace.repeat(currentPosition)}href: ${href}
+  ${attributeSpace.repeat(currentPosition)}uid: #optional string
+  ${attributeSpace.repeat(currentPosition)}expanded: #true or false, false is default`;
     insertContentToEditor(editor, insertTocEntryWithOptions.name, tocEntryWithOptionsIndented);
   }
   showStatusMessage(insertedTocEntry);
@@ -228,23 +228,22 @@ export function createParentNode() {
   }
   const position = editor.selection.active;
   const cursorPosition = position.character;
-  const attributeSpace = "  ";
-  const indentedSpace = "    ";
+  const attributeSpace = " ";
 
-  const parentNodeLineStart = `- name:
+  if (cursorPosition === 0) {
+    const parentNodeLineStart = `- name:
   items:
   - name:
     href:`
-
-  const parentNodeIndented = `- name:
-  ${attributeSpace}items:
-  ${attributeSpace}- name:
-  ${indentedSpace}href:`
-
-  if (cursorPosition === 0) {
     insertContentToEditor(editor, insertTocEntry.name, parentNodeLineStart);
   }
   if (cursorPosition > 0) {
+    const currentPosition = editor.selection.active.character;
+    const parentNodeIndented =
+      `- name:
+  ${attributeSpace.repeat(currentPosition)}items:
+  ${attributeSpace.repeat(currentPosition)}- name:
+  ${attributeSpace.repeat(currentPosition + 2)}href:`
     insertContentToEditor(editor, insertTocEntry.name, parentNodeIndented);
   }
 }


### PR DESCRIPTION
1. Moved template strings into position if statements.
2. Use cursor position to determine indent instead of relying on fixed spacing.