### PR TITLE
Fixed issue with fuzzy search.

### DIFF
--- a/docs-yaml/package-lock.json
+++ b/docs-yaml/package-lock.json
@@ -265,10 +265,15 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
-        "fuzzysearch": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/fuzzysearch/-/fuzzysearch-1.0.3.tgz",
-            "integrity": "sha1-3/yA9tawQiPyImqnndGUIxCW0Ag="
+        "fuse.js": {
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.5.tgz",
+            "integrity": "sha512-s9PGTaQIkT69HaeoTVjwGsLfb8V8ScJLx5XGFcKHg0MqLUH/UZ4EKOtqtXX9k7AFqCGxD1aJmYb8Q5VYDibVRQ=="
+        },
+        "fuzzy-search": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/fuzzy-search/-/fuzzy-search-3.0.1.tgz",
+            "integrity": "sha512-rjUvzdsMlOyarm0oD5k6zVQwgvt4Tb5Xe3YdIGU+Vogw54+ueAGPUTMU2B9jfPQEie5cD11i/S9J9d+MNBSQ3Q=="
         },
         "getpass": {
             "version": "0.1.7",

--- a/docs-yaml/package.json
+++ b/docs-yaml/package.json
@@ -45,10 +45,10 @@
         "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
     "dependencies": {
-        "fuzzysearch": "^1.0.3",
+        "fuse.js": "^3.4.5",
         "js-yaml": "^3.13.1",
-        "web-request": "^1.0.7",
-        "vscode-extension-telemetry": "^0.1.1"
+        "vscode-extension-telemetry": "^0.1.1",
+        "web-request": "^1.0.7"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.32",


### PR DESCRIPTION
Fuzzy Search was causing an error when getting called. This switches the package out with one that works. Same functionality just using a different package.

This fixes an issue with using auto-complete for Yaml Templates. We should now be able to type "yaml" **ctrl + space** and get auto-completion for YamlMime type templates along with toc **ctrl + space** to get TOC templates.