### PR TITLE
Resolve parent node indentation error

### DIFF
--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.18 (TBD)
+
+- TOC parent node bugfix
+
 ## 0.2.17 (September 9th, 2019)
 
 - TOC href link bugfix

--- a/docs-markdown/src/controllers/yaml-controller.ts
+++ b/docs-markdown/src/controllers/yaml-controller.ts
@@ -228,7 +228,6 @@ export function createParentNode() {
   }
   const position = editor.selection.active;
   const cursorPosition = position.character;
-  const attributeSpace = " ";
 
   if (cursorPosition === 0) {
     const parentNodeLineStart = `- name:
@@ -236,15 +235,9 @@ export function createParentNode() {
   - name:
     href:`
     insertContentToEditor(editor, insertTocEntry.name, parentNodeLineStart);
-  }
-  if (cursorPosition > 0) {
-    const currentPosition = editor.selection.active.character;
-    const parentNodeIndented =
-      `- name:
-  ${attributeSpace.repeat(currentPosition)}items:
-  ${attributeSpace.repeat(currentPosition)}- name:
-  ${attributeSpace.repeat(currentPosition + 2)}href:`
-    insertContentToEditor(editor, insertTocEntry.name, parentNodeIndented);
+  } else {
+    window.showErrorMessage(invalidTocEntryPosition);
+    return;
   }
 }
 


### PR DESCRIPTION
Parent nodes should not be indented so updating the logic to insert the node if the cursor position is at the beginning of a line.