### PR TITLE
Update quickpick to use language identifier instead of file extension

### DIFF
--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.19 (TBD)
+
+- Support for yaml file extension/language
+
 ## 0.2.18 (September 13th, 2019)
 
 - TOC parent node bugfix

--- a/docs-markdown/src/controllers/quick-pick-menu-controller.ts
+++ b/docs-markdown/src/controllers/quick-pick-menu-controller.ts
@@ -144,13 +144,12 @@ export function markdownQuickPick() {
     );
 
     if (activeTextDocument) {
-        const activeFilePath = activeTextDocument.document.fileName;
-        fileExtension = detectFileExtension(activeFilePath);
-        switch (fileExtension) {
-            case ".md":
+        const activeDocumentLanguage = activeTextDocument.document.languageId;
+        switch (activeDocumentLanguage) {
+            case "markdown":
                 items = markdownItems;
                 break;
-            case ".yml":
+            case "yaml":
                 items = yamlItems;
                 break;
         }

--- a/docs-markdown/src/controllers/quick-pick-menu-controller.ts
+++ b/docs-markdown/src/controllers/quick-pick-menu-controller.ts
@@ -2,7 +2,7 @@
 
 import * as vscode from "vscode";
 import { output } from "../extension";
-import { checkExtension, detectFileExtension, generateTimestamp } from "../helper/common";
+import { checkExtension, generateTimestamp } from "../helper/common";
 import { insertAlert } from "./alert-controller";
 import { formatBold } from "./bold-controller";
 import { applyCleanup } from "./cleanup-controller";
@@ -33,7 +33,6 @@ export function markdownQuickPick() {
     const yamlItems: vscode.QuickPickItem[] = [];
     let items: vscode.QuickPickItem[] = [];
     const activeTextDocument = vscode.window.activeTextEditor;
-    let fileExtension: string;
 
     if (checkExtension("docsmsft.docs-preview")) {
         markdownItems.push({


### PR DESCRIPTION
Update logic to use VS Code language detection instead of using the file extension.  Both .yml and .yaml files should show quickpick options.
