### PR TITLE
Support tilde in file path preview

### DIFF
--- a/docs-preview/src/markdown-extensions/codesnippet.ts
+++ b/docs-preview/src/markdown-extensions/codesnippet.ts
@@ -1,15 +1,20 @@
 import { resolve } from "path";
 import { readFileSync } from "fs";
-import { window } from "vscode";
+import { window, workspace } from "vscode";
 
 export const output = window.createOutputChannel("docs-preview");
 
 export const CODE_RE = /\[!code-(.+?)\s*\[\s*.+?\s*]\(\s*(.+?)\s*\)\s*]/i;
+const ROOTPATH_RE = /.*~/gmi;
 export function codeSnippets(md, options) {
   const replaceCodeSnippetWithContents = (src: string, rootdir: string) => {
     let captureGroup;
     while ((captureGroup = CODE_RE.exec(src))) {
-      const filePath = resolve(rootdir, captureGroup[2].trim());
+      const repoRoot = workspace.workspaceFolders[0].uri.fsPath;
+      let filePath = resolve(rootdir, captureGroup[2].trim());
+      if (filePath.includes("~")) {
+        filePath = filePath.replace(ROOTPATH_RE, repoRoot);
+      }
       let mdSrc = readFileSync(filePath, "utf8");
       mdSrc = `\`\`\`${captureGroup[1].trim()}\r\n${mdSrc}\r\n\`\`\``;
       src = src.slice(0, captureGroup.index) + mdSrc + src.slice(captureGroup.index + captureGroup[0].length, src.length);

--- a/docs-preview/src/markdown-extensions/codesnippet.ts
+++ b/docs-preview/src/markdown-extensions/codesnippet.ts
@@ -1,6 +1,7 @@
 import { resolve } from "path";
 import { readFileSync } from "fs";
 import { output } from "../extension";
+import { workspace } from "vscode";
 
 export const CODE_RE = /\[!code-(.+?)\s*\[\s*.+?\s*]\(\s*(.+?)\s*\)\s*]/i;
 const ROOTPATH_RE = /.*~/gmi;

--- a/docs-preview/src/markdown-extensions/includes.ts
+++ b/docs-preview/src/markdown-extensions/includes.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "fs";
 import { resolve } from "path";
 import { output } from "../extension";
+import { workspace } from "vscode";
 
 const INCLUDE_RE = /\[!include\s*\[\s*.+?\s*]\(\s*(.+?)\s*\)\s*]/i;
 const FRONTMATTER_RE = /^---[\s\S]+?---/gmi;


### PR DESCRIPTION
Add tilde regex to includes.ts and codesnippet.ts 

- used to replace **~** with the repo root path so the include/snippet source file can be read
- updated path is not written back to the markdown file and surrounding text is not affected

 