### PR TITLE
feat: cleanup go.microsoft.com links

### DIFF
--- a/docs-markdown/src/controllers/cleanup-controller.ts
+++ b/docs-markdown/src/controllers/cleanup-controller.ts
@@ -538,6 +538,8 @@ function handleLinksWithRegex(data: string) {
     data = data.replace(akaRegex, "https://aka.ms");
     const microsoftRegex = new RegExp(/http:\/\/microsoft.com/g);
     data = data.replace(microsoftRegex, "https://microsoft.com");
+    const goMicrosoftRegex = new RegExp(/http:\/\/go.microsoft.com/g);
+    data = data.replace(goMicrosoftRegex, "https://go.microsoft.com");
     const visualstudioRegex = new RegExp(/http:\/\/visualstudio.com/g);
     data = data.replace(visualstudioRegex, "https://visualstudio.com");
     const officeRegex = new RegExp(/http:\/\/office.com/g);


### PR DESCRIPTION
These now get flagged by OpenBuild, but aren't cleaned up by the controller