### PR TITLE
add blackmist.LinkCheckMD to DAP

### DIFF
--- a/docs-authoring-pack/CHANGELOG.md
+++ b/docs-authoring-pack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.1.4 (March 27th, 2019)
+
+- [blackmist.LinkCheckMD](https://marketplace.visualstudio.com/items?itemName=blackmist.LinkCheckMD) is now part of Docs Authoring Pack
+
 ## 0.1.2 (March 27th, 2019)
 
 - [docs-yaml](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-yaml) is now part of Docs Authoring Pack.

--- a/docs-authoring-pack/package-lock.json
+++ b/docs-authoring-pack/package-lock.json
@@ -1,5 +1,5 @@
 {
     "name": "docs-authoring-pack",
-    "version": "0.1.1",
+    "version": "0.1.4",
     "lockfileVersion": 1
 }

--- a/docs-authoring-pack/package.json
+++ b/docs-authoring-pack/package.json
@@ -3,7 +3,7 @@
   "displayName": "Docs Authoring Pack",
   "description": "Collection of extensions to assist with content development for docs.microsoft.com",
   "icon": "images/docs-logo-ms.png",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "docsmsft",
   "engines": {
     "vscode": "^1.20.0"
@@ -28,7 +28,8 @@
     "docsmsft.docs-article-templates",
     "streetsidesoftware.code-spell-checker",
     "docsmsft.docs-yaml",
-    "docsmsft.docs-metadata"
+    "docsmsft.docs-metadata",
+    "blackmist.LinkCheckMD"
   ],
   "license": "MIT"
 }

--- a/docs-authoring-pack/readme.md
+++ b/docs-authoring-pack/readme.md
@@ -9,6 +9,7 @@ The Docs Authoring Pack provides the following extensions to help author content
 * [Docs Article Templates](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-article-templates), which allows users to apply Markdown skeleton content to new files.
 * [Docs YAML](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-yaml), which validates Docs .yml files against the appropriate YAML schemas.
 * [Docs Metadata](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-metadata), which speeds up editing of metadata throughout a Docs repository.
+* [LinkCheckMD](https://marketplace.visualstudio.com/items?itemName=blackmist.LinkCheckMD), which generates a report on the links in the document, including broken links.
 
 ## Prerequisites and assumptions
 


### PR DESCRIPTION
Testing steps:
* Uninstall docs-authoring-pack and all dependencies
* pull branch
* create package: run `vsce package` in `docs-authoring-pack` folder
* install packaged vsix
* verify all dependent extensions are installed, including blackmist.LinkCheckMD