### PR TITLE
Added triple colon code snippet support

### DIFF
--- a/docs-markdown/markdownlint-custom-rules/codesnippet.js
+++ b/docs-markdown/markdownlint-custom-rules/codesnippet.js
@@ -13,90 +13,106 @@ module.exports = {
         try {
             const doc = params.lines.join("\n");
             const fullLooseMatches = doc.match(common.syntaxCodeLooseMatch);
-            params.tokens.filter(function filterToken(token) {
-                return token.type === "inline";
-            }).map(text => {
-                let content = fullLooseMatches.filter((regexMatch) => regexMatch == text.content)
-                if (content == null || content.length == 0) {
-                    content = fullLooseMatches.filter(regexMatch => regexMatch == text.line)
-                }
-                if (content == null || content.length == 0) {
-                    return;
-                }
+            if (fullLooseMatches) {
+                params.tokens.filter(function filterToken(token) {
+                    return token.type === "inline";
+                }).map(text => {
+                    let content = fullLooseMatches.filter((regexMatch) => regexMatch == text.content)
+                    if (content == null || content.length == 0) {
+                        content = fullLooseMatches.filter(regexMatch => regexMatch == text.line)
+                    }
+                    if (content == null || content.length == 0) {
+                        return;
+                    }
 
-                content = content[0]
-                //malformed colons
-                if (!content.match(common.openAndClosingValidTripleColon)) {
-                    onError({
-                        lineNumber: text.lineNumber,
-                        detail: detailStrings.tripleColonsIncorrect,
-                        context: text.line
-                    });
-                }
-
-                //source check
-                const sourceMatch = content.match(common.codeSourceMatch);
-                if (!sourceMatch || sourceMatch[0] === "source=\"\"") {
-                    onError({
-                        lineNumber: text.lineNumber,
-                        detail: detailStrings.codeSourceRequired,
-                        context: text.line
-                    });
-                }
-
-                //do we have language?
-                const languageMatch = content.match(common.codeLanguageMatch);
-                if (!languageMatch || languageMatch[0] === "language=\"\"") {
-                    onError({
-                        lineNumber: text.lineNumber,
-                        detail: detailStrings.codeLanguageRequired,
-                        context: text.line
-                    });
-                }
-
-                //do we have both Id and Range?
-                const rangeMatch = content.match(common.codeRangeMatch);
-                const idMatch = content.match(common.codeIdMatch);
-                if (rangeMatch && idMatch) {
-                    onError({
-                        lineNumber: text.lineNumber,
-                        detail: detailStrings.codeRangeOrId,
-                        context: text.line
-                    });
-                } else if (rangeMatch) {
-                    const allowedValues = rangeMatch[1].match(common.allowedRangeValues)
-                    if (!allowedValues) {
+                    content = content[0]
+                    //malformed colons
+                    if (!content.match(common.openAndClosingValidTripleColon)) {
                         onError({
                             lineNumber: text.lineNumber,
-                            detail: detailStrings.allowedRangeValues,
+                            detail: detailStrings.tripleColonsIncorrect,
                             context: text.line
                         });
                     }
-                }
 
-                //case sensitivity and attributes check
-                let attrMatches = content.match(common.syntaxCodeAttributes);
-                attrMatches = attrMatches.filter((attr) => attr != "");
-                attrMatches.forEach((attr) => {
-                    if (attr) {
-                        if (attr !== attr.toLowerCase()) {
+                    //source check
+                    const sourceMatch = content.match(common.codeSourceMatch);
+                    if (!sourceMatch || sourceMatch[0] === "source=\"\"") {
+                        onError({
+                            lineNumber: text.lineNumber,
+                            detail: detailStrings.codeSourceRequired,
+                            context: text.line
+                        });
+                    }
+
+                    //do we have language?
+                    // const languageMatch = content.match(common.codeLanguageMatch);
+                    // if (!languageMatch || languageMatch[0] === "language=\"\"") {
+                    //     onError({
+                    //         lineNumber: text.lineNumber,
+                    //         detail: detailStrings.codeLanguageRequired,
+                    //         context: text.line
+                    //     });
+                    // }
+
+                    //do we have both Id and Range?
+                    const rangeMatch = content.match(common.codeRangeMatch);
+                    const idMatch = content.match(common.codeIdMatch);
+                    if (rangeMatch && idMatch) {
+                        onError({
+                            lineNumber: text.lineNumber,
+                            detail: detailStrings.codeRangeOrId,
+                            context: text.line
+                        });
+                    } else if (rangeMatch) {
+                        const allowedValues = rangeMatch[1].match(common.allowedRangeValues)
+                        if (!allowedValues) {
                             onError({
                                 lineNumber: text.lineNumber,
-                                detail: detailStrings.codeCaseSensitive,
-                                context: text.line
-                            });
-                        }
-                        //make sure each attribute is allowed...
-                        if (common.allowedCodeAttributes.indexOf(attr) === -1) {
-                            onError({
-                                lineNumber: text.lineNumber,
-                                detail: detailStrings.codeNonAllowedAttribute.replace("___", attr),
+                                detail: detailStrings.allowedRangeValues,
                                 context: text.line
                             });
                         }
                     }
+
+                    //case sensitivity and attributes check
+                    let attrMatches = content.match(common.syntaxCodeAttributes);
+                    attrMatches = attrMatches.filter((attr) => attr != "");
+                    attrMatches.forEach((attr) => {
+                        if (attr) {
+                            if (attr !== attr.toLowerCase()) {
+                                onError({
+                                    lineNumber: text.lineNumber,
+                                    detail: detailStrings.codeCaseSensitive,
+                                    context: text.line
+                                });
+                            }
+                            //make sure each attribute is allowed...
+                            if (common.allowedCodeAttributes.indexOf(attr) === -1) {
+                                onError({
+                                    lineNumber: text.lineNumber,
+                                    detail: detailStrings.codeNonAllowedAttribute.replace("___", attr),
+                                    context: text.line
+                                });
+                            }
+                        }
+                    });
+
+                    const interactiveMatches = content.match(common.codeInteractiveMatch)
+                    if (interactiveMatches) {
+                        if (interactiveMatches.length > 0) {
+                            const allowedValue = common.allowedInteractiveValues.includes(interactiveMatches[1]);
+                            if (!allowedValue) {
+                                onError({
+                                    lineNumber: text.lineNumber,
+                                    detail: detailStrings.allowedInteractiveValues.replace("___", interactiveMatches[1]),
+                                    context: text.line
+                                });
+                            }
+                        }
+                    }
                 });
-            });
+            }
         } catch (error) {
             console.log(error);
         }

--- a/docs-markdown/markdownlint-custom-rules/codesnippet.js
+++ b/docs-markdown/markdownlint-custom-rules/codesnippet.js
@@ -1,0 +1,145 @@
+// @ts-check
+
+"use strict";
+
+const common = require("./common");
+const detailStrings = require("./strings");
+
+module.exports = {
+    "names": ["DOCSMD012", "docsmd.codesnippet"],
+    "description": `codesnippet linting.`,
+    "tags": ["validation"],
+    "function": function rule(params, onError) {
+        try {
+            const doc = params.lines.join("\n");
+            const fullLooseMatches = doc.match(common.syntaxCodeLooseMatch);
+            params.tokens.filter(function filterToken(token) {
+                return token.type === "inline";
+            }).map(text => {
+                let content = fullLooseMatches.filter((regexMatch) => regexMatch == text.content)
+                if (content == null) {
+                    content = fullLooseMatches.filter(regexMatch => regexMatch == text.line)
+                }
+                if (content == null || content.length == 0) {
+                    return;
+                }
+
+                content = content[0]
+                //malformed colons
+                if (!content.match(common.openAndClosingValidTripleColon)) {
+                    onError({
+                        lineNumber: text.lineNumber,
+                        detail: detailStrings.tripleColonsIncorrect,
+                        context: text.line
+                    });
+                }
+
+                //source check
+                // const notImageComplexEndTagMatch = content.match(common.imageComplexEndTagMatch)
+                // if (!notImageComplexEndTagMatch) {
+                const sourceMatch = content.match(common.imageSourceMatch);
+                if (!sourceMatch || sourceMatch[0] === "source=\"\"") {
+                    onError({
+                        lineNumber: text.lineNumber,
+                        detail: detailStrings.imageSourceRequired,
+                        context: text.line
+                    });
+                }
+                // }
+
+                //case sensitivity and attributes check
+                let attrMatches = content.match(common.syntaxImageAttributes);
+                attrMatches = attrMatches.filter((attr) => attr != "");
+                attrMatches.forEach((attr) => {
+                    if (attr !== attr.toLowerCase()) {
+                        onError({
+                            lineNumber: text.lineNumber,
+                            detail: detailStrings.codeCaseSensitive,
+                            context: text.line
+                        });
+                    }
+
+                    //make sure each attribute is allowed...
+                    if (common.allowedCodeAttributes.indexOf(attr) === -1) {
+                        onError({
+                            lineNumber: text.lineNumber,
+                            detail: detailStrings.codeNonAllowedAttribute.replace("___", attr),
+                            context: text.line
+                        });
+                    }
+                });
+
+                //check if the type is valid
+                const typeMatch = common.imageTypeMatch.exec(content);
+                if (typeMatch) {
+                    if (common.allowedImageTypes.indexOf(typeMatch[1]) === -1) {
+                        onError({
+                            lineNumber: text.lineNumber,
+                            detail: detailStrings.imageNonAllowedType.replace("___", typeMatch[1]),
+                            context: text.line
+                        });
+                    }
+
+
+
+                    if (typeMatch[1] !== "icon") {
+                        //do we have alt-text?
+                        const altTextMatch = content.match(common.imageAltTextMatch);
+                        if (!altTextMatch || altTextMatch[0] === "alt-text=\"\"") {
+                            onError({
+                                lineNumber: text.lineNumber,
+                                detail: detailStrings.imageAltTextRequired,
+                                context: text.line
+                            });
+                        }
+
+                        //complex type rules
+                        if (typeMatch[1] === "complex") {
+                            //do we have an "image-end" tag?
+                            const imageMatches = content.match(common.imageOpen);
+                            if (imageMatches.length > 2 || !content.match(common.imageComplexEndTagMatch)) {
+                                onError({
+                                    lineNumber: text.lineNumber,
+                                    detail: detailStrings.imageComplexEndTagRequired,
+                                    context: text.line
+                                });
+                            }
+
+                            //do we have a long description?
+                            const longDescMatch = common.imageLongDescriptionMatch.exec(content);
+                            if (!longDescMatch || longDescMatch[9].match(/^\s*$/mi)[0] != "") {
+                                onError({
+                                    lineNumber: text.lineNumber,
+                                    detail: detailStrings.imageComplexLongDescriptionRequired,
+                                    context: text.line
+                                });
+                            }
+                        }
+                    } else {
+                        //do we have loc-scope? cuzzz, we shouldn't!
+                        const locScopeMatch = common.imageLocScopeMatch.exec(content);
+                        if (locScopeMatch) {
+                            onError({
+                                lineNumber: text.lineNumber,
+                                detail: detailStrings.imageIconRemoveLocScope,
+                                context: text.line
+                            });
+                        }
+                        //do we have alt-text? cuzzz, we shouldn't!
+                        const altTextMatch = common.imageAltTextMatch.exec(content);
+                        if (altTextMatch) {
+                            onError({
+                                lineNumber: text.lineNumber,
+                                detail: detailStrings.imageIconRemoveAltText,
+                                context: text.line
+                            });
+                        }
+                    }
+                };
+            });
+        } catch (error) {
+            console.log(error);
+        }
+    }
+
+};

--- a/docs-markdown/markdownlint-custom-rules/common.js
+++ b/docs-markdown/markdownlint-custom-rules/common.js
@@ -85,4 +85,14 @@ module.exports.syntaxColumn = /^\s+:{3}(column|column-end|column\s+(.*)"):{3}$/g
 module.exports.columnWithAttribute = /^\s+:{3}(column\s+(.*?)):/gm;
 module.exports.columnSpan = /^\s+:{3}(column\s+span="(.*?)"):/gm;
 
+//codesnippet
+module.exports.syntaxCodeLooseMatch = /(:+)(\s+)?code.*?(:+)/gmi;
+module.exports.syntaxCodeExactMatch = /:::(\s+)?code\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"(\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"(\s+)?)?:::/gmi;
+module.exports.syntaxCodeAttributes = /(:code)|([a-z-]*(?==))/gmi;
+module.exports.allowedCodeAttributes = [":code", "language", "source", "range", "id"];
+module.exports.codeSourceMatch = /source="(.*?)"/m;
+module.exports.codeOpen = /:::code/gmi;
+module.exports.codeLanguageMatch = /language="(.*?)"/m;
+module.exports.codeRangeMatch = /range="(.*?)"/m;
+module.exports.codeIdMatch = /id="(.*?)"/m;
 

--- a/docs-markdown/markdownlint-custom-rules/common.js
+++ b/docs-markdown/markdownlint-custom-rules/common.js
@@ -88,7 +88,7 @@ module.exports.columnSpan = /^\s+:{3}(column\s+span="(.*?)"):/gm;
 //codesnippet
 module.exports.syntaxCodeLooseMatch = /(:+)(\s+)?code.*?(:+)/g;
 module.exports.syntaxCodeExactMatch = /:::(\s+)?code\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"(\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"(\s+)?)?:::/i;
-module.exports.syntaxCodeAttributes = /(:code)|([a-z]*(?==))/i;
+module.exports.syntaxCodeAttributes = /([a-z]*(?==))/g;
 module.exports.allowedCodeAttributes = [":code", "language", "source", "range", "id", "interactive", "highlight"];
 module.exports.codeOpen = /:::code/i;
 module.exports.codeSourceMatch = /source="(.*?)"/;
@@ -96,5 +96,7 @@ module.exports.codeLanguageMatch = /language="(.*?)"/;
 module.exports.codeRangeMatch = /range="(.*?)"/;
 module.exports.codeIdMatch = /id="(.*?)"/;
 module.exports.allowedRangeValues = /[0-9\- ,]+/;
+module.exports.codeInteractiveMatch = /interactive="(.*?)"/;
+module.exports.allowedInteractiveValues = ["try-dotnet", "try-dotnet-method", "try-dotnet-class", "cloudshell-powershell", "cloudshell-bash"]
 
 

--- a/docs-markdown/markdownlint-custom-rules/common.js
+++ b/docs-markdown/markdownlint-custom-rules/common.js
@@ -10,7 +10,7 @@ module.exports.openAndClosingValidTripleColon = /^:::(.*):::/gmi;
 
 // Markdown extensions (add valid/supported extensions to list)
 module.exports.openExtension = /^:(.*?)(zone|moniker|no-loc)/gm;
-module.exports.supportedExtensions = /^:::\s?(zone|moniker|row|column|form|no-loc|image)(.:*)/g;
+module.exports.supportedExtensions = /^:::\s?(zone|moniker|row|column|form|no-loc|image|code)(.:*)/g;
 module.exports.unsupportedExtensionRegex = /^:::\s+(.*)/gm;
 
 // Zones
@@ -45,9 +45,9 @@ module.exports.imageTypeMatch = /type\s*=\s*"([a-z]*)"/m;
 module.exports.imageLongDescriptionMatch = /(:::)(.*)(:::)(((\s)*(.*))+)(:::)(.*)(:::)/mi;
 module.exports.imageComplexEndTagMatch = /:::(\s*)?image-end:::/gmi;
 module.exports.imageOpen = /:::image/gmi;
-module.exports.imageSourceMatch = /source\s*=\s*"([a-zA-Z0-9\-_\.\,\;\:\\/\?\=\%\@s*]*)"/m;
-module.exports.imageAltTextMatch = /alt-text\s*=\s*"([a-zA-Z\-_\.\,\;\:\s*]*)"/m;
-module.exports.imageLocScopeMatch = /loc-scope\s*=\s*"([a-zA-Z\-_\.\,\;\:\s*]*)"/m;
+module.exports.imageSourceMatch = /source\s*=\s*"(.*?)"/m;
+module.exports.imageAltTextMatch = /alt-text\s*=\s*"(.*?)"/m;
+module.exports.imageLocScopeMatch = /loc-scope\s*=\s*"(.*?)"/m;
 
 // Alert
 module.exports.alertOpener = /^>\s+\[!/gm; // regex to find "> [!"
@@ -86,13 +86,15 @@ module.exports.columnWithAttribute = /^\s+:{3}(column\s+(.*?)):/gm;
 module.exports.columnSpan = /^\s+:{3}(column\s+span="(.*?)"):/gm;
 
 //codesnippet
-module.exports.syntaxCodeLooseMatch = /(:+)(\s+)?code.*?(:+)/gmi;
-module.exports.syntaxCodeExactMatch = /:::(\s+)?code\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"(\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"(\s+)?)?:::/gmi;
-module.exports.syntaxCodeAttributes = /(:code)|([a-z-]*(?==))/gmi;
-module.exports.allowedCodeAttributes = [":code", "language", "source", "range", "id"];
-module.exports.codeSourceMatch = /source="(.*?)"/m;
-module.exports.codeOpen = /:::code/gmi;
-module.exports.codeLanguageMatch = /language="(.*?)"/m;
-module.exports.codeRangeMatch = /range="(.*?)"/m;
-module.exports.codeIdMatch = /id="(.*?)"/m;
+module.exports.syntaxCodeLooseMatch = /(:+)(\s+)?code.*?(:+)/g;
+module.exports.syntaxCodeExactMatch = /:::(\s+)?code\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"(\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"(\s+)?)?:::/i;
+module.exports.syntaxCodeAttributes = /(:code)|([a-z]*(?==))/i;
+module.exports.allowedCodeAttributes = [":code", "language", "source", "range", "id", "interactive", "highlight"];
+module.exports.codeOpen = /:::code/i;
+module.exports.codeSourceMatch = /source="(.*?)"/;
+module.exports.codeLanguageMatch = /language="(.*?)"/;
+module.exports.codeRangeMatch = /range="(.*?)"/;
+module.exports.codeIdMatch = /id="(.*?)"/;
+module.exports.allowedRangeValues = /[0-9\- ,]+/;
+
 

--- a/docs-markdown/markdownlint-custom-rules/image.js
+++ b/docs-markdown/markdownlint-custom-rules/image.js
@@ -31,7 +31,7 @@ module.exports = {
                     if (!content.match(common.openAndClosingValidTripleColon)) {
                         onError({
                             lineNumber: text.lineNumber,
-                            detail: detailStrings.imageColonsIncorrect,
+                            detail: detailStrings.tripleColonsIncorrect,
                             context: text.line
                         });
                     }

--- a/docs-markdown/markdownlint-custom-rules/rules.js
+++ b/docs-markdown/markdownlint-custom-rules/rules.js
@@ -11,5 +11,6 @@ module.exports = [
   require("./row-extension-syntax"),
   require("./column-extension-syntax"),
   require("./colomn-span-attribute"),
-  require("./image")
+  require("./image"),
+  require("./codesnippet")
 ];

--- a/docs-markdown/markdownlint-custom-rules/strings.js
+++ b/docs-markdown/markdownlint-custom-rules/strings.js
@@ -2,7 +2,7 @@
 module.exports.syntaxCount = `Bad syntax for markdown extension. Begin with "::: ".`;
 module.exports.syntaxSpace = `Bad syntax for markdown extension. One space required after ":::".`;
 module.exports.syntaxUnsupportedExtension = `Bad syntax for markdown extension. Extension is not supported.`;
-module.exports.imageColonsIncorrect = `Bad syntax for markdown extension. Begins and end with ":::".`;
+module.exports.tripleColonsIncorrect = `Bad syntax for markdown extension. Begins and end with ":::".`;
 
 // moniker
 module.exports.monikerRange = `Bad syntax for range argument. Use =, <=, or >=, and put value in quotes.`;
@@ -52,5 +52,12 @@ module.exports.rowSyntax = `Rows should begin :::row::: and end with :::row-end:
 // column
 module.exports.columnSyntax = `Columns should begin :::column::: and end with :::column-end:::).`;
 module.exports.contenSpanAttribute = `Only span is supported (ex. :::column span="":::).`;
+
+// image
+module.exports.codeCaseSensitive = `Bad syntax for codesnippet. "code" and its attributes must be lower-case.`;
+module.exports.codeNonAllowedAttribute = `Bad syntax for codesnippet. "___" is not an allowed attribute.`;
+module.exports.codeSourceRequired = `Bad syntax for codesnippet. "source" required.`;
+module.exports.codeLanguageRequired = `Bad syntax for codesnippet. "language" required.`;
+module.exports.codeRangeOrId = `Bad syntax for codesnippet. You cannot have both "range" and "id" properties. Choose one or the other.`;
 
 

--- a/docs-markdown/markdownlint-custom-rules/strings.js
+++ b/docs-markdown/markdownlint-custom-rules/strings.js
@@ -53,11 +53,12 @@ module.exports.rowSyntax = `Rows should begin :::row::: and end with :::row-end:
 module.exports.columnSyntax = `Columns should begin :::column::: and end with :::column-end:::).`;
 module.exports.contenSpanAttribute = `Only span is supported (ex. :::column span="":::).`;
 
-// image
+// codesnippet
 module.exports.codeCaseSensitive = `Bad syntax for codesnippet. "code" and its attributes must be lower-case.`;
 module.exports.codeNonAllowedAttribute = `Bad syntax for codesnippet. "___" is not an allowed attribute.`;
 module.exports.codeSourceRequired = `Bad syntax for codesnippet. "source" required.`;
 module.exports.codeLanguageRequired = `Bad syntax for codesnippet. "language" required.`;
 module.exports.codeRangeOrId = `Bad syntax for codesnippet. You cannot have both "range" and "id" properties. Choose one or the other.`;
+module.exports.allowedRangeValues = `Bad syntax for codesnippet. Allowed range values must match the regex [0-9\- ,]+.`;
 
 

--- a/docs-markdown/markdownlint-custom-rules/strings.js
+++ b/docs-markdown/markdownlint-custom-rules/strings.js
@@ -54,11 +54,12 @@ module.exports.columnSyntax = `Columns should begin :::column::: and end with ::
 module.exports.contenSpanAttribute = `Only span is supported (ex. :::column span="":::).`;
 
 // codesnippet
-module.exports.codeCaseSensitive = `Bad syntax for codesnippet. "code" and its attributes must be lower-case.`;
-module.exports.codeNonAllowedAttribute = `Bad syntax for codesnippet. "___" is not an allowed attribute.`;
-module.exports.codeSourceRequired = `Bad syntax for codesnippet. "source" required.`;
-module.exports.codeLanguageRequired = `Bad syntax for codesnippet. "language" required.`;
-module.exports.codeRangeOrId = `Bad syntax for codesnippet. You cannot have both "range" and "id" properties. Choose one or the other.`;
-module.exports.allowedRangeValues = `Bad syntax for codesnippet. Allowed range values must match the regex [0-9\- ,]+.`;
+module.exports.codeCaseSensitive = `"code" and its attributes must be lower-case.`;
+module.exports.codeNonAllowedAttribute = `"___" is not an allowed attribute. Allowed attributes include "language", "source", "range", "id", "interactive", "highlight"`;
+module.exports.codeSourceRequired = `"source" is required.`;
+module.exports.codeLanguageRequired = `"language" is required.`;
+module.exports.codeRangeOrId = `You cannot have both "range" and "id" properties. Choose one or the other.`;
+module.exports.allowedRangeValues = `Allowed range values must match the regex [0-9\- ,]+.`;
+module.exports.allowedInteractiveValues = `"___" is not an allowed value for interactive. Allowed values include: "try-dotnet", "try-dotnet-method", "try-dotnet-class", "cloudshell-powershell", "cloudshell-bash"`;
 
 

--- a/docs-markdown/src/controllers/snippet-controller.ts
+++ b/docs-markdown/src/controllers/snippet-controller.ts
@@ -57,7 +57,7 @@ export function searchRepo() {
 
     scopeOptions.push({ label: "Full Search", description: "Look in all directories for snippet" });
     scopeOptions.push({ label: "Scoped Search", description: "Look in specific directories for snippet" });
-    scopeOptions.push({ label: "Cross-Reference Repo", description: "Reference GitHub repository" });
+    scopeOptions.push({ label: "Cross-Repository Reference", description: "Reference GitHub repository" });
 
     vscode.window.showQuickPick(scopeOptions).then(async function searchType(selection) {
         if (!selection) {

--- a/docs-markdown/src/controllers/snippet-controller.ts
+++ b/docs-markdown/src/controllers/snippet-controller.ts
@@ -78,6 +78,12 @@ export function searchRepo(searchTerm: any) {
                         dirOptions.push({ label: subdirs[folders], description: "sub directory" });
                     }
                 }
+
+                vscode.window.showQuickPick(dirOptions).then((directory) => {
+                    if (directory) {
+                        search(editor, selected, searchTerm, directory.label)
+                    }
+                });
             });
         }
     });

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -126,16 +126,108 @@ export function search(editor: vscode.TextEditor, selection: vscode.Selection, s
             if (!selected) {
                 return;
             }
+
             const target = path.parse(selected.description);
             const relativePath = path.relative(activeFilePath, target.dir);
+
+            const dict = [
+                { actionscript: [".as"] },
+                { arduino: [".ino"] },
+                { assembly: ["nasm", ".asm"] },
+                { batchfile: [".bat", ".cmd"] },
+                { cpp: ["c", "c++", "objective-c", "obj-c", "objc", "objectivec", ".c", ".cpp", ".h", ".hpp", ".cc"] },
+                { csharp: ["cs", ".cs"] },
+                { cuda: [".cu", ".cuh"] },
+                { d: ["dlang", ".d"] },
+                { erlang: [".erl"] },
+                { fsharp: ["fs", ".fs", ".fsi", ".fsx"] },
+                { go: ["golang", ".go"] },
+                { haskell: [".hs"] },
+                { html: [".html", ".jsp", ".asp", ".aspx", ".ascx"] },
+                { cshtml: [".cshtml", "aspx-cs", "aspx-csharp"] },
+                { vbhtml: [".vbhtml", "aspx-vb"] },
+                { java: [".java"] },
+                { javascript: ["js", "node", ".js"] },
+                { lisp: [".lisp", ".lsp"] },
+                { lua: [".lua"] },
+                { matlab: [".matlab"] },
+                { pascal: [".pas"] },
+                { perl: [".pl"] },
+                { php: [".php"] },
+                { powershell: ["posh", ".ps1"] },
+                { processing: [".pde"] },
+                { python: [".py"] },
+                { r: [".r"] },
+                { ruby: ["ru", ".ru", ".ruby"] },
+                { rust: [".rs"] },
+                { scala: [".scala"] },
+                { shell: ["sh", "bash", ".sh", ".bash"] },
+                { smalltalk: [".st"] },
+                { sql: [".sql"] },
+                { swift: [".swift"] },
+                { typescript: ["ts", ".ts"] },
+                { xaml: [".xaml"] },
+                { xml: ["xsl", "xslt", "xsd", "wsdl", ".xml", ".csdl", ".edmx", ".xsl", ".xslt", ".xsd", ".wsdl"] },
+                { vb: ["vbnet", "vbscript", ".vb", ".bas", ".vbs", ".vba"] }
+            ]
             const ext: string = target.ext;
+            let language: string = "";
+            for (const key in dict) {
+                if (dict.hasOwnProperty(key)) {
+                    const element: any = dict[key];
+                    for (const extension in element) {
+                        if (element.hasOwnProperty(extension)) {
+                            const val: string[] = element[extension];
+                            for (const x in val) {
+                                if (val[x] === ext) {
+                                    language = extension;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (!language) {
+                language = ext.substr(1);
+            }
             // change path separator syntax for commonmark
             const snippetLink = path.join(relativePath, target.base).replace(/\\/g, "/");
-            const snippet: string = snippetBuilder(ext.substr(1), target.name, snippetLink);
-            const range = new vscode.Range(selection.start.line, selection.start.character, selection.end.line, selection.end.character);
+            const selectionRange = new vscode.Range(selection.start.line, selection.start.character, selection.end.line, selection.end.character);
 
-            common.insertContentToEditor(editor, search.name, snippet, true, range);
+            const selectorOptions: vscode.QuickPickItem[] = [];
+            selectorOptions.push({ label: "Id", description: "Select code by id tag (for example: // <section>)" });
+            selectorOptions.push({ label: "Range", description: "Select code by line range (for example: 1-15,18,20)" });
+            selectorOptions.push({ label: "None", description: "Select entire file" });
 
+            vscode.window.showQuickPick(selectorOptions).then((selectorChoice) => {
+                if (selectorChoice) {
+                    let id: string;
+                    let range: string;
+                    switch (selectorChoice.label.toLowerCase()) {
+                        case "id":
+                            vscode.window.showInputBox({ prompt: "Enter id to select" }).then((id) => {
+                                if (id) {
+                                    const snippet: string = snippetBuilder(language, snippetLink, id, range);
+                                    common.insertContentToEditor(editor, search.name, snippet, true, selectionRange);
+                                }
+                            });
+                            break;
+                        case "range":
+                            vscode.window.showInputBox({ prompt: "Enter line selection range" }).then((range) => {
+                                if (range) {
+                                    const snippet: string = snippetBuilder(language, snippetLink, id, range);
+                                    common.insertContentToEditor(editor, search.name, snippet, true, selectionRange);
+                                }
+                            });
+                            break;
+                        default:
+                            const snippet: string = snippetBuilder(language, snippetLink);
+                            common.insertContentToEditor(editor, search.name, snippet, true, selectionRange);
+                            break;
+                    }
+                }
+            });
         });
     });
 }
@@ -194,11 +286,14 @@ export function includeBuilder(link: string, title: string) {
 
 }
 
-export function snippetBuilder(codeFileExtension: string, targetName: string, relativePath: string) {
-
-    const snippet: string = "[!code-" + codeFileExtension + "[" + targetName + "](" + relativePath + ")]";
-
-    return snippet;
+export function snippetBuilder(codeFileExtension: string, relativePath: string, id?: string, range?: string) {
+    if (id) {
+        return ":::code language=\"" + codeFileExtension + "\" source=\"" + relativePath + "\" id=\"" + id + "\":::"
+    } else if (range) {
+        return ":::code language=\"" + codeFileExtension + "\" source=\"" + relativePath + "\" range=\"" + range + "\":::"
+    } else {
+        return ":::code language=\"" + codeFileExtension + "\" source=\"" + relativePath + "\":::";
+    }
 }
 
 /**

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -94,20 +94,24 @@ export function tableBuilder(col: number, row: number) {
  * @param {string} fullPath - optional, the folder to start the search under.
  */
 
-export function search(editor: vscode.TextEditor, selection: vscode.Selection, searchTerm: string, folderPath: string, fullPath?: string) {
+export async function search(editor: vscode.TextEditor, selection: vscode.Selection, folderPath: string, fullPath?: string, crossReference?: string) {
     const dir = require("node-dir");
     const path = require("path");
-
-    if (fullPath == null) {
-        fullPath = folderPath;
-    }
-
-    // searches for all files at the given directory path.
-    dir.files(fullPath, (err: any, files: any) => {
-        if (err) {
-            throw err;
+    let language: string = "";
+    let selected: vscode.QuickPickItem | undefined;
+    let activeFilePath
+    let snippetLink: string = "";
+    if (!crossReference) {
+        let searchTerm = await vscode.window.showInputBox({ prompt: "Enter snippet search terms." })
+        if (!searchTerm) {
+            return;
+        }
+        if (fullPath == null) {
+            fullPath = folderPath;
         }
 
+        // searches for all files at the given directory path.
+        const files = await dir.promiseFiles(fullPath);
         const fileOptions: vscode.QuickPickItem[] = [];
 
         for (const file in files) {
@@ -121,115 +125,128 @@ export function search(editor: vscode.TextEditor, selection: vscode.Selection, s
         }
 
         // select from all files found that match search term.
-        vscode.window.showQuickPick(fileOptions).then(function searchType(selected) {
-            const activeFilePath = (path.parse(editor.document.fileName).dir);
-            if (!selected) {
-                return;
+        selected = await vscode.window.showQuickPick(fileOptions);
+        activeFilePath = (path.parse(editor.document.fileName).dir);
+        if (!selected) {
+            return;
+        }
+        const target = path.parse(selected.description);
+        const relativePath = path.relative(activeFilePath, target.dir);
+
+        language = getLanguage(language, target.ext);
+
+        // change path separator syntax for commonmark
+        snippetLink = path.join(relativePath, target.base).replace(/\\/g, "/");
+    } else {
+        const inputRepoPath = await vscode.window.showInputBox({ prompt: "Enter file path for Cross-Reference GitHub Repo" });
+        if (inputRepoPath) {
+            language = getLanguage(language, inputRepoPath.split(".").pop());
+            snippetLink = `~/${crossReference}/${inputRepoPath}`;
+        }
+    }
+    const selectionRange = new vscode.Range(selection.start.line, selection.start.character, selection.end.line, selection.end.character);
+
+    const selectorOptions: vscode.QuickPickItem[] = [];
+    selectorOptions.push({ label: "Id", description: "Select code by id tag (for example: <Snippet1>)" });
+    selectorOptions.push({ label: "Range", description: "Select code by line range (for example: 1-15,18,20)" });
+    selectorOptions.push({ label: "None", description: "Select entire file" });
+
+    vscode.window.showQuickPick(selectorOptions).then((selectorChoice) => {
+        if (selectorChoice) {
+            let id: string;
+            let range: string;
+            switch (selectorChoice.label.toLowerCase()) {
+                case "id":
+                    vscode.window.showInputBox({ prompt: "Enter id to select" }).then((id) => {
+                        if (id) {
+                            const snippet: string = snippetBuilder(language, snippetLink, id, range);
+                            common.insertContentToEditor(editor, search.name, snippet, true, selectionRange);
+                        }
+                    });
+                    break;
+                case "range":
+                    vscode.window.showInputBox({ prompt: "Enter line selection range" }).then((range) => {
+                        if (range) {
+                            const snippet: string = snippetBuilder(language, snippetLink, id, range);
+                            common.insertContentToEditor(editor, search.name, snippet, true, selectionRange);
+                        }
+                    });
+                    break;
+                default:
+                    const snippet: string = snippetBuilder(language, snippetLink);
+                    common.insertContentToEditor(editor, search.name, snippet, true, selectionRange);
+                    break;
             }
+        }
+    });
+}
 
-            const target = path.parse(selected.description);
-            const relativePath = path.relative(activeFilePath, target.dir);
+function getLanguage(language: string, ext: string | undefined) {
+    if (!ext) {
+        return language;
+    }
+    const dict = [
+        { actionscript: [".as"] },
+        { arduino: [".ino"] },
+        { assembly: ["nasm", ".asm"] },
+        { batchfile: [".bat", ".cmd"] },
+        { cpp: ["c", "c++", "objective-c", "obj-c", "objc", "objectivec", ".c", ".cpp", ".h", ".hpp", ".cc"] },
+        { csharp: ["cs", ".cs"] },
+        { cuda: [".cu", ".cuh"] },
+        { d: ["dlang", ".d"] },
+        { erlang: [".erl"] },
+        { fsharp: ["fs", ".fs", ".fsi", ".fsx"] },
+        { go: ["golang", ".go"] },
+        { haskell: [".hs"] },
+        { html: [".html", ".jsp", ".asp", ".aspx", ".ascx"] },
+        { cshtml: [".cshtml", "aspx-cs", "aspx-csharp"] },
+        { vbhtml: [".vbhtml", "aspx-vb"] },
+        { java: [".java"] },
+        { javascript: ["js", "node", ".js"] },
+        { lisp: [".lisp", ".lsp"] },
+        { lua: [".lua"] },
+        { matlab: [".matlab"] },
+        { pascal: [".pas"] },
+        { perl: [".pl"] },
+        { php: [".php"] },
+        { powershell: ["posh", ".ps1"] },
+        { processing: [".pde"] },
+        { python: [".py"] },
+        { r: [".r"] },
+        { ruby: ["ru", ".ru", ".ruby"] },
+        { rust: [".rs"] },
+        { scala: [".scala"] },
+        { shell: ["sh", "bash", ".sh", ".bash"] },
+        { smalltalk: [".st"] },
+        { sql: [".sql"] },
+        { swift: [".swift"] },
+        { typescript: ["ts", ".ts"] },
+        { xaml: [".xaml"] },
+        { xml: ["xsl", "xslt", "xsd", "wsdl", ".xml", ".csdl", ".edmx", ".xsl", ".xslt", ".xsd", ".wsdl"] },
+        { vb: ["vbnet", "vbscript", ".vb", ".bas", ".vbs", ".vba"] }
+    ]
 
-            const dict = [
-                { actionscript: [".as"] },
-                { arduino: [".ino"] },
-                { assembly: ["nasm", ".asm"] },
-                { batchfile: [".bat", ".cmd"] },
-                { cpp: ["c", "c++", "objective-c", "obj-c", "objc", "objectivec", ".c", ".cpp", ".h", ".hpp", ".cc"] },
-                { csharp: ["cs", ".cs"] },
-                { cuda: [".cu", ".cuh"] },
-                { d: ["dlang", ".d"] },
-                { erlang: [".erl"] },
-                { fsharp: ["fs", ".fs", ".fsi", ".fsx"] },
-                { go: ["golang", ".go"] },
-                { haskell: [".hs"] },
-                { html: [".html", ".jsp", ".asp", ".aspx", ".ascx"] },
-                { cshtml: [".cshtml", "aspx-cs", "aspx-csharp"] },
-                { vbhtml: [".vbhtml", "aspx-vb"] },
-                { java: [".java"] },
-                { javascript: ["js", "node", ".js"] },
-                { lisp: [".lisp", ".lsp"] },
-                { lua: [".lua"] },
-                { matlab: [".matlab"] },
-                { pascal: [".pas"] },
-                { perl: [".pl"] },
-                { php: [".php"] },
-                { powershell: ["posh", ".ps1"] },
-                { processing: [".pde"] },
-                { python: [".py"] },
-                { r: [".r"] },
-                { ruby: ["ru", ".ru", ".ruby"] },
-                { rust: [".rs"] },
-                { scala: [".scala"] },
-                { shell: ["sh", "bash", ".sh", ".bash"] },
-                { smalltalk: [".st"] },
-                { sql: [".sql"] },
-                { swift: [".swift"] },
-                { typescript: ["ts", ".ts"] },
-                { xaml: [".xaml"] },
-                { xml: ["xsl", "xslt", "xsd", "wsdl", ".xml", ".csdl", ".edmx", ".xsl", ".xslt", ".xsd", ".wsdl"] },
-                { vb: ["vbnet", "vbscript", ".vb", ".bas", ".vbs", ".vba"] }
-            ]
-            const ext: string = target.ext;
-            let language: string = "";
-            for (const key in dict) {
-                if (dict.hasOwnProperty(key)) {
-                    const element: any = dict[key];
-                    for (const extension in element) {
-                        if (element.hasOwnProperty(extension)) {
-                            const val: string[] = element[extension];
-                            for (const x in val) {
-                                if (val[x] === ext) {
-                                    language = extension;
-                                    break;
-                                }
-                            }
+    for (const key in dict) {
+        if (dict.hasOwnProperty(key)) {
+            const element: any = dict[key];
+            for (const extension in element) {
+                if (element.hasOwnProperty(extension)) {
+                    const val: string[] = element[extension];
+                    for (const x in val) {
+                        if (val[x] === ext) {
+                            language = extension;
+                            break;
                         }
                     }
                 }
             }
-            if (!language) {
-                language = ext.substr(1);
-            }
-            // change path separator syntax for commonmark
-            const snippetLink = path.join(relativePath, target.base).replace(/\\/g, "/");
-            const selectionRange = new vscode.Range(selection.start.line, selection.start.character, selection.end.line, selection.end.character);
+        }
+    }
+    if (!language) {
+        return ext.substr(1);
+    }
 
-            const selectorOptions: vscode.QuickPickItem[] = [];
-            selectorOptions.push({ label: "Id", description: "Select code by id tag (for example: // <section>)" });
-            selectorOptions.push({ label: "Range", description: "Select code by line range (for example: 1-15,18,20)" });
-            selectorOptions.push({ label: "None", description: "Select entire file" });
-
-            vscode.window.showQuickPick(selectorOptions).then((selectorChoice) => {
-                if (selectorChoice) {
-                    let id: string;
-                    let range: string;
-                    switch (selectorChoice.label.toLowerCase()) {
-                        case "id":
-                            vscode.window.showInputBox({ prompt: "Enter id to select" }).then((id) => {
-                                if (id) {
-                                    const snippet: string = snippetBuilder(language, snippetLink, id, range);
-                                    common.insertContentToEditor(editor, search.name, snippet, true, selectionRange);
-                                }
-                            });
-                            break;
-                        case "range":
-                            vscode.window.showInputBox({ prompt: "Enter line selection range" }).then((range) => {
-                                if (range) {
-                                    const snippet: string = snippetBuilder(language, snippetLink, id, range);
-                                    common.insertContentToEditor(editor, search.name, snippet, true, selectionRange);
-                                }
-                            });
-                            break;
-                        default:
-                            const snippet: string = snippetBuilder(language, snippetLink);
-                            common.insertContentToEditor(editor, search.name, snippet, true, selectionRange);
-                            break;
-                    }
-                }
-            });
-        });
-    });
+    return language
 }
 
 export function internalLinkBuilder(isArt: boolean, pathSelection: any, selectedText: string = "") {
@@ -286,13 +303,13 @@ export function includeBuilder(link: string, title: string) {
 
 }
 
-export function snippetBuilder(codeFileExtension: string, relativePath: string, id?: string, range?: string) {
+export function snippetBuilder(language: string, relativePath: string, id?: string, range?: string) {
     if (id) {
-        return ":::code language=\"" + codeFileExtension + "\" source=\"" + relativePath + "\" id=\"" + id + "\":::"
+        return ":::code language=\"" + language + "\" source=\"" + relativePath + "\" id=\"" + id + "\":::"
     } else if (range) {
-        return ":::code language=\"" + codeFileExtension + "\" source=\"" + relativePath + "\" range=\"" + range + "\":::"
+        return ":::code language=\"" + language + "\" source=\"" + relativePath + "\" range=\"" + range + "\":::"
     } else {
-        return ":::code language=\"" + codeFileExtension + "\" source=\"" + relativePath + "\":::";
+        return ":::code language=\"" + language + "\" source=\"" + relativePath + "\":::";
     }
 }
 

--- a/docs-preview/package-lock.json
+++ b/docs-preview/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-preview",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -588,6 +588,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
+    },
+    "js-base64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
+      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/docs-preview/package.json
+++ b/docs-preview/package.json
@@ -93,6 +93,7 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
+    "js-base64": "^2.5.1",
     "markdown-it": "^8.4.2",
     "markdown-it-include": "^1.1.0",
     "vscode-extension-telemetry": "^0.1.1"

--- a/docs-preview/src/extension.ts
+++ b/docs-preview/src/extension.ts
@@ -6,7 +6,7 @@ import { commands, ExtensionContext, TextDocument, window } from "vscode";
 import { sendTelemetryData } from "./helper/common";
 import { Reporter } from "./helper/telemetry";
 import { include } from "./markdown-extensions/includes";
-import { codeSnippets, custom_codeblock } from "./markdown-extensions/codesnippet";
+import { codeSnippets, custom_codeblock, tripleColonCodeSnippets } from "./markdown-extensions/codesnippet";
 import { columnOptions, column_end } from "./markdown-extensions/column";
 import { container_plugin } from "./markdown-extensions/container";
 import { rowOptions } from "./markdown-extensions/row";
@@ -40,6 +40,7 @@ export function activate(context: ExtensionContext) {
         extendMarkdownIt(md) {
             return md.use(include, { root: workingPath })
                 .use(codeSnippets, { root: workingPath })
+                .use(tripleColonCodeSnippets, { root: workingPath })
                 .use(xref)
                 .use(custom_codeblock)
                 .use(column_end)

--- a/docs-preview/src/extension.ts
+++ b/docs-preview/src/extension.ts
@@ -6,10 +6,10 @@ import { commands, ExtensionContext, TextDocument, window } from "vscode";
 import { sendTelemetryData } from "./helper/common";
 import { Reporter } from "./helper/telemetry";
 import { include } from "./markdown-extensions/includes";
-import { codeSnippets, custom_codeblock, tripleColonCodeSnippets } from "./markdown-extensions/codesnippet";
-import { columnOptions, column_end } from "./markdown-extensions/column";
+import { codeSnippets, tripleColonCodeSnippets } from "./markdown-extensions/codesnippet";
+import { columnOptions, column_end, columnEndOptions } from "./markdown-extensions/column";
 import { container_plugin } from "./markdown-extensions/container";
-import { rowOptions } from "./markdown-extensions/row";
+import { rowOptions, rowEndOptions } from "./markdown-extensions/row";
 import { xref } from "./xref/xref";
 import { div_plugin, divOptions } from "./markdown-extensions/div";
 import { imageOptions, image_end } from "./markdown-extensions/image";
@@ -42,10 +42,11 @@ export function activate(context: ExtensionContext) {
                 .use(codeSnippets, { root: workingPath })
                 .use(tripleColonCodeSnippets, { root: workingPath })
                 .use(xref)
-                .use(custom_codeblock)
                 .use(column_end)
                 .use(container_plugin, "row", rowOptions)
+                .use(container_plugin, "row-end", rowEndOptions)
                 .use(container_plugin, "column", columnOptions)
+                .use(container_plugin, "column-end", columnEndOptions)
                 .use(div_plugin, "div", divOptions)
                 .use(container_plugin, "image", imageOptions)
                 .use(image_end);

--- a/docs-preview/src/markdown-extensions/codesnippet.ts
+++ b/docs-preview/src/markdown-extensions/codesnippet.ts
@@ -1,9 +1,11 @@
-import { resolve } from "path";
-import { readFileSync, open } from "fs";
-import { output as outputChannel } from "../extension";
-import { workspace, window, Position } from "vscode";
 import Axios from "axios";
+import { open, readFileSync } from "fs";
 import { Base64 } from "js-base64"
+import { resolve } from "path";
+import { Position, window, workspace } from "vscode";
+import { output as outputChannel } from "../extension";
+
+//async fs does not have import module available
 const fs = require('fs');
 const util = require('util');
 const readFile = util.promisify(fs.readFile);
@@ -36,88 +38,47 @@ export function codeSnippets(md, options) {
   md.core.ruler.before("normalize", "codesnippet", importCodeSnippet);
 }
 
-// // C# code snippet comment block: // <[/]snippetname>
-// const CFamilyCodeSnippetCommentStartLineTemplate = /\/\/<{tagname}>/g;
-// const CFamilyCodeSnippetCommentEndLineTemplate = /\/\/<\/{tagname}>/g;
-
-// // C# code snippet region block: start -> #region snippetname, end -> #endregion
-// const CSharpCodeSnippetRegionStartLineTemplate = /#region{tagname}/g;
-// const CSharpCodeSnippetRegionEndLineTemplate = /#endregion/g;
-
-// // VB code snippet comment block: ' <[/]snippetname>
-// const BasicFamilyCodeSnippetCommentStartLineTemplate = /'<{tagname}>/g;
-// const BasicFamilyCodeSnippetCommentEndLineTemplate = /'<\/{tagname}>/g;
-
-// // VB code snippet Region block: start -> # Region /snippetname/, end -> # End Region
-// const VBCodeSnippetRegionRegionStartLineTemplate = /#region {tagname}/g;
-// const VBCodeSnippetRegionRegionEndLineTemplate = /#endregion/g;
-
-// // XML code snippet block: <!-- <[/]snippetname> -->
-// const MarkupLanguageFamilyCodeSnippetCommentStartLineTemplate = /<!--<{tagname}>-->/g;
-// const MarkupLanguageFamilyCodeSnippetCommentEndLineTemplate = /<!--<\/{tagname}>-->/g;
-
-// // Sql code snippet block: -- <[/]snippetname>
-// const SqlFamilyCodeSnippetCommentStartLineTemplate = /--<{tagname}>/g;
-// const SqlFamilyCodeSnippetCommentEndLineTemplate = /--<\/{tagname}>/g;
-
-// // Python code snippet comment block: # <[/]snippetname>
-// const ScriptFamilyCodeSnippetCommentStartLineTemplate = /#<{tagname}>/g;
-// const ScriptFamilyCodeSnippetCommentEndLineTemplate = /#<\/{tagname}>/g;
-
-// // Batch code snippet comment block: rem <[/]snippetname>
-// const BatchFileCodeSnippetRegionStartLineTemplate = /rem<{tagname}>/g;
-// const BatchFileCodeSnippetRegionEndLineTemplate = /rem<\/{tagname}>/g;
-
-// // Erlang code snippet comment block: % <[/]snippetname>
-// const ErlangCodeSnippetRegionStartLineTemplate = /%<{tagname}>/g;
-// const ErlangCodeSnippetRegionEndLineTemplate = /%<{tagname}>/g;
-
-// // Lisp code snippet comment block: ; <[/]snippetname>
-// const LispCodeSnippetRegionStartLineTemplate = /;<{tagname}>/g;
-// const LispCodeSnippetRegionEndLineTemplate = /;<{tagname}>/g;
-
 const dict = [
   { actionscript: [".as"] },
   { arduino: [".ino"] },
   { assembly: ["nasm", ".asm"] },
-  // { batchfile: [".bat", ".cmd"] },
-  // { cpp: ["c", "c++", "objective-c", "obj-c", "objc", "objectivec", ".c", ".cpp", ".h", ".hpp", ".cc"] },
-  // { csharp: ["cs", ".cs"] },
+  { batchfile: [".bat", ".cmd"] },
+  { cpp: ["c", "c++", "objective-c", "obj-c", "objc", "objectivec", ".c", ".cpp", ".h", ".hpp", ".cc"] },
+  { csharp: ["cs", ".cs"] },
   { cuda: [".cu", ".cuh"] },
   { d: ["dlang", ".d"] },
-  // { erlang: [".erl"] },
-  // { fsharp: ["fs", ".fs", ".fsi", ".fsx"] },
-  // { go: ["golang", ".go"] },
+  { erlang: [".erl"] },
+  { fsharp: ["fs", ".fs", ".fsi", ".fsx"] },
+  { go: ["golang", ".go"] },
   { haskell: [".hs"] },
-  // { html: [".html", ".jsp", ".asp", ".aspx", ".ascx"] },
+  { html: [".html", ".jsp", ".asp", ".aspx", ".ascx"] },
   { cshtml: [".cshtml", "aspx-cs", "aspx-csharp"] },
   { vbhtml: [".vbhtml", "aspx-vb"] },
-  // { java: [".java"] },
-  // { javascript: ["js", "node", ".js"] },
-  // { lisp: [".lisp", ".lsp"] },
+  { java: [".java"] },
+  { javascript: ["js", "node", ".js"] },
+  { lisp: [".lisp", ".lsp"] },
   { lua: [".lua"] },
   { matlab: [".matlab"] },
   { pascal: [".pas"] },
   { perl: [".pl"] },
-  // { php: [".php"] },
-  // { powershell: ["posh", ".ps1"] },
+  { php: [".php"] },
+  { powershell: ["posh", ".ps1"] },
   { processing: [".pde"] },
-  // { python: [".py"] },
+  { python: [".py"] },
   { r: [".r"] },
-  // { ruby: ["ru", ".ru", ".ruby"] },
-  // { rust: [".rs"] },
+  { ruby: ["ru", ".ru", ".ruby"] },
+  { rust: [".rs"] },
   { scala: [".scala"] },
-  // { shell: ["sh", "bash", ".sh", ".bash"] },
+  { shell: ["sh", "bash", ".sh", ".bash"] },
   { smalltalk: [".st"] },
-  // { sql: [".sql"] },
+  { sql: [".sql"] },
   { swift: [".swift"] },
-  // { typescript: ["ts", ".ts"] },
+  { typescript: ["ts", ".ts"] },
   { xaml: [".xaml"] },
-  // { xml: ["xsl", "xslt", "xsd", "wsdl", ".xml", ".csdl", ".edmx", ".xsl", ".xslt", ".xsd", ".wsdl"] },
-  // { vb: ["vbnet", "vbscript", ".vb", ".bas", ".vbs", ".vba"] }
+  { xml: ["xsl", "xslt", "xsd", "wsdl", ".xml", ".csdl", ".edmx", ".xsl", ".xslt", ".xsd", ".wsdl"] },
+  { vb: ["vbnet", "vbscript", ".vb", ".bas", ".vbs", ".vba"] }
 ]
 let codeSnippetContent = "";
-let firstIteration = true;
 const fileMap = new Map();
 const TRIPLE_COLON_CODE_RE = /:::(\s+)?code\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"(\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"(\s+)?)?:::/g;
 const SOURCE_RE = /source="(.*?)"/i;
@@ -130,7 +91,6 @@ export function tripleColonCodeSnippets(md, options) {
     const matches = src.match(TRIPLE_COLON_CODE_RE);
     for (const match of matches) {
       let file;
-      let filePath;
       let shouldUpdate = false;
       let output = "";
       const lineArr: string[] = [];
@@ -143,43 +103,41 @@ export function tripleColonCodeSnippets(md, options) {
           shouldUpdate = true;
           const repoRoot = workspace.workspaceFolders[0].uri.fsPath;
           if (path.includes("~")) {
-            let apiUrl;
             // get openpublishing.json at root
-            const openPublishingRepos = await getOpenPublishingFile(repoRoot)
+            const openPublishingRepos = await getOpenPublishingFile(repoRoot);
             if (openPublishingRepos) {
-              apiUrl = buildRepoPath(openPublishingRepos, path);
-            }
-            try {
-              await Axios.get(apiUrl)
-                .then(response => {
-                  if (response) {
-                    if (response.status === 403) {
-                      outputChannel.appendLine("Github Rate Limit has been reached. 60 calls per hour are allowed.")
-                    } else if (response.status === 404) {
-                      outputChannel.appendLine("Resource not Found.")
-                    } else if (response.status === 200) {
-                      file = Base64.decode(response.data.content);
-                      fileMap.set(path, file)
+              const apiUrl = buildRepoPath(openPublishingRepos, path);
+              try {
+                await Axios.get(apiUrl)
+                  .then((response) => {
+                    if (response) {
+                      if (response.status === 403) {
+                        outputChannel.appendLine("Github Rate Limit has been reached. 60 calls per hour are allowed.");
+                      } else if (response.status === 404) {
+                        outputChannel.appendLine("Resource not Found.");
+                      } else if (response.status === 200) {
+                        file = Base64.decode(response.data.content);
+                        fileMap.set(path, file);
+                      }
                     }
-                  }
-                });
-            } catch (error) {
-              outputChannel.appendLine(error);
+                  });
+              } catch (error) {
+                outputChannel.appendLine(error);
+              }
             }
           } else {
-            filePath = resolve(rootdir, path);
-            file = await readFile(filePath, "utf8")
-            fileMap.set(path, file)
+            file = await readFile(resolve(rootdir, path), "utf8");
+            fileMap.set(path, file);
           }
         }
       }
       if (file) {
         const data = file.split("\n");
         const language = checkLanguageMatch(match);
-        const range = match.match(RANGE_RE)
+        const range = match.match(RANGE_RE);
         const idMatch = match.match(ID_RE);
         if (idMatch) {
-          output = idToOutput(idMatch, lineArr, data, language)
+          output = idToOutput(idMatch, lineArr, data, language);
         } else if (range) {
           output = rangeToOutput(lineArr, data, range);
         } else {
@@ -218,15 +176,15 @@ function updateEditorToRefreshChanges() {
     editor.edit((update) => {
       const range = editor.document.getWordRangeAtPosition(position, /[ ]+/g);
       update.delete(range);
-    })
+    });
   });
 }
 
 function buildRepoPath(repos, path) {
-  let position = 0
+  let position = 0;
   let repoPath = "";
-  const parts = path.split("/")
-  repos.map(repo => {
+  const parts = path.split("/");
+  repos.map((repo: { path_to_root: string; url: string; }) => {
     if (parts) {
       parts.map((part, index) => {
         if (repo.path_to_root === part) {
@@ -237,27 +195,26 @@ function buildRepoPath(repos, path) {
       });
     }
   });
-  let fullPath = [];
+  const fullPath = [];
   repoPath = repoPath.replace("https://github.com/", "https://api.github.com/repos/")
   fullPath.push(repoPath);
-  fullPath.push("contents")
+  fullPath.push("contents");
   for (let index = position + 1; index < parts.length; index++) {
-    const path = parts[index];
-    fullPath.push(path);
+    fullPath.push(parts[index]);
   }
-  return fullPath.join("/");
+  return encodeURI(fullPath.join("/"));
 }
 
 async function getOpenPublishingFile(repoRoot) {
-  const openPublishingFilePath = resolve(repoRoot, ".openpublishing.publish.config.json")
-  const openPublishingFile = await readFile(openPublishingFilePath, "utf8")
+  const openPublishingFilePath = resolve(repoRoot, ".openpublishing.publish.config.json");
+  const openPublishingFile = await readFile(openPublishingFilePath, "utf8");
   // filePath = filePath.replace(ROOTPATH_RE, repoRoot);
-  const openPublishingJson = JSON.parse(openPublishingFile)
-  return openPublishingJson["dependent_repositories"]
+  const openPublishingJson = JSON.parse(openPublishingFile);
+  return openPublishingJson.dependent_repositories;
 }
 
 function checkLanguageMatch(match) {
-  let languageMatch = LANGUAGE_RE.exec(match);
+  const languageMatch = LANGUAGE_RE.exec(match);
   let language = ""
   if (languageMatch) {
     language = languageMatch[1].trim()
@@ -295,92 +252,14 @@ function idToOutput(idMatch, lineArr, data, language) {
   const id = idMatch[1].trim();
   let startLine = 0;
   let endLine = 0;
-  let START_RE
-  let START_SPACE_RE
-  let END_RE
-  let END_SPACE_RE
+  const START_RE = new RegExp(`((<|#region)\s*${id}(>|(\s*>)))`, "i");
+  const END_RE = new RegExp(`(</|#endregion)\s*${id}(\s*>)`, "i");
   // logic for id.
-  // get language to know what type of comment to expect
-  switch (language) {
-    case "cpp":
-    case "vb":
-    case "java":
-    case "javascript":
-    case "js":
-    case "fsharp":
-    case "typescript":
-    case "go":
-    case "php":
-    case "rust":
-    case "objectivec":
-      START_RE = new RegExp(`\/\/<${id}>`)
-      START_SPACE_RE = new RegExp(`\/\/ <${id}>`);;
-      END_RE = new RegExp(`\/\/<\/${id}>`)
-      END_SPACE_RE = new RegExp(`\/\/ <\/${id}>`);
-      break;
-    case "cs":
-    case "csharp":
-      START_RE = new RegExp(`#region${id}`)
-      START_SPACE_RE = new RegExp(`#region ${id}`);
-      END_RE = new RegExp(`#endregion`);
-      END_SPACE_RE = new RegExp(`#endregion`);
-      break;
-    case "xml":
-    case "html":
-      START_RE = new RegExp(`<!--<${id}>-->`)
-      START_SPACE_RE = new RegExp(`<!-- <${id}> -->`)
-      END_RE = new RegExp(`<!--<\/${id}>-->`)
-      END_SPACE_RE = new RegExp(`<!-- </${id}> -->`)
-      break;
-    case "sql":
-      START_RE = new RegExp(`--<${id}>`)
-      START_SPACE_RE = new RegExp(`-- <${id}>`);
-      END_RE = new RegExp(`-- <\/${id}>`)
-      END_SPACE_RE = new RegExp(`--<\/${id}>`);
-      break;
-    case "python":
-    case "powershell":
-    case "shell":
-    case "ruby":
-      START_RE = new RegExp(`#<${id}>`);
-      START_SPACE_RE = new RegExp(`# <${id}>`);
-      END_RE = new RegExp(`#<\/${id}>`);
-      END_SPACE_RE = new RegExp(`# <\/${id}>`);
-      break;
-    case "batchfile":
-      START_RE = new RegExp(`rem<${id}>`, "i");
-      START_SPACE_RE = new RegExp(`rem <${id}>`, "i");
-      END_RE = new RegExp(`rem<\/${id}>`, "i");
-      END_SPACE_RE = new RegExp(`rem <\/${id}>`, "i");
-      break;
-    case "erlang":
-      START_RE = new RegExp(`%<${id}>`);
-      START_SPACE_RE = new RegExp(`% <${id}>`);
-      END_RE = new RegExp(`%</${id}>`);
-      END_SPACE_RE = new RegExp(`% </${id}>`);
-      break;
-    case "lisp":
-      START_RE = new RegExp(`;<${id}>`);
-      START_SPACE_RE = new RegExp(`; <${id}>`);
-      END_RE = new RegExp(`;</${id}>`);
-      END_SPACE_RE = new RegExp(`; </${id}>`);
-      break;
-    default:
-      // get all lines
-      startLine = 0;
-      endLine = data.length;
-      break;
-  }
   for (let index = 0; index < data.length; index++) {
     if (START_RE.exec(data[index])) {
       startLine = index;
-    } else if (START_SPACE_RE.exec(data[index])) {
-      startLine = index;
     }
     if (END_RE.exec(data[index])) {
-      endLine = index;
-      break;
-    } else if (END_SPACE_RE.exec(data[index])) {
       endLine = index;
       break;
     }

--- a/docs-preview/src/markdown-extensions/codesnippet.ts
+++ b/docs-preview/src/markdown-extensions/codesnippet.ts
@@ -1,7 +1,9 @@
 import { resolve } from "path";
-import { readFileSync } from "fs";
+import { readFileSync, createReadStream } from "fs";
 import { output } from "../extension";
 import { workspace } from "vscode";
+import { createInterface } from "readline"
+import * as reader from "readline-sync";
 
 export const CODE_RE = /\[!code-(.+?)\s*\[\s*.+?\s*]\(\s*(.+?)\s*\)\s*]/i;
 const ROOTPATH_RE = /.*~/gmi;
@@ -30,6 +32,77 @@ export function codeSnippets(md, options) {
   };
   md.core.ruler.before("normalize", "codesnippet", importCodeSnippet);
 }
+
+export const TRIPLE_COLON_CODE_RE = /:::(\s+)?code\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"\s+((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?")?(\s+)?:::/i;
+export function tripleColonCodeSnippets(md, options) {
+  const replaceTripleColonCodeSnippetWithContents = (src: string, rootdir: string) => {
+    let captureGroup;
+    while ((captureGroup = TRIPLE_COLON_CODE_RE.exec(src))) {
+      const repoRoot = workspace.workspaceFolders[0].uri.fsPath;
+      const SOURCE_RE = /source="(.*?)"/g;
+      const source = SOURCE_RE.exec(captureGroup[0]);
+      const LANGUAGE_RE = /language="(.*?)"/g;
+      const language = LANGUAGE_RE.exec(captureGroup[0]);
+      let output = "";
+      let filePath = resolve(rootdir, source[1].trim());
+      if (filePath.includes("~")) {
+
+        filePath = filePath.replace(ROOTPATH_RE, repoRoot);
+      }
+      let mdSrc = readFileSync(filePath, "utf8")
+        .split('\n')
+        .filter(Boolean);
+      const RANGE_RE = /range="(.*?)"/g;
+      const range = RANGE_RE.exec(captureGroup[0]);
+      const ID_RE = /id="(.*?)"/g;
+      const id = ID_RE.exec(captureGroup[0]);
+      const rangeArr: number[] = [];
+      if (range) {
+        const rangeList = range[1].split(",");
+        rangeList.forEach((element) => {
+          if (element.indexOf("-") > 0) {
+            const rangeThru = element.split("-");
+            const startRange = parseInt(rangeThru[0]);
+            const endRange = parseInt(rangeThru.pop());
+            for (let index = startRange; index <= endRange; index++) {
+              rangeArr.push(index);
+            }
+          } else {
+            rangeArr.push(parseInt(element));
+          }
+        });
+        rangeArr.sort();
+        const lineArr: string[] = [];
+        mdSrc.map((line, index) => {
+          rangeArr.filter(x => {
+            var thing = x === index + 1
+            if (thing) {
+              lineArr.push(line);
+            }
+          })
+        });
+        output = lineArr.join("\n");
+      } else if (id) {
+        // logic for id.
+      } else {
+        output = readFileSync(filePath, "utf8")
+      }
+      output = `\`\`\`${language[1].trim()}\r\n${output}\r\n\`\`\``;
+      src = src.slice(0, captureGroup.index) + output + src.slice(captureGroup.index + captureGroup[0].length, src.length);
+    }
+    return src;
+  };
+
+  const importTripleColonCodeSnippets = (state) => {
+    try {
+      state.src = replaceTripleColonCodeSnippetWithContents(state.src, options.root);
+    } catch (error) {
+      output.appendLine(error);
+    }
+  };
+  md.core.ruler.before("normalize", "codesnippet", importTripleColonCodeSnippets);
+}
+
 
 export function custom_codeblock(md, options) {
   const CODEBLOCK_RE = /([ ]{5})/g;

--- a/docs-preview/src/markdown-extensions/codesnippet.ts
+++ b/docs-preview/src/markdown-extensions/codesnippet.ts
@@ -1,7 +1,12 @@
 import { resolve } from "path";
-import { readFileSync } from "fs";
-import { output } from "../extension";
+import { readFileSync, open } from "fs";
+import { output as outputChannel } from "../extension";
 import { workspace, window, Position } from "vscode";
+import Axios from "axios";
+import { Base64 } from "js-base64"
+const fs = require('fs');
+const util = require('util');
+const readFile = util.promisify(fs.readFile);
 
 export const CODE_RE = /\[!code-(.+?)\s*\[\s*.+?\s*]\(\s*(.+?)\s*\)\s*]/i;
 const ROOTPATH_RE = /.*~/gmi;
@@ -25,7 +30,7 @@ export function codeSnippets(md, options) {
     try {
       state.src = replaceCodeSnippetWithContents(state.src, options.root);
     } catch (error) {
-      output.appendLine(error);
+      outputChannel.appendLine(error);
     }
   };
   md.core.ruler.before("normalize", "codesnippet", importCodeSnippet);
@@ -44,7 +49,7 @@ export function codeSnippets(md, options) {
 // const BasicFamilyCodeSnippetCommentEndLineTemplate = /'<\/{tagname}>/g;
 
 // // VB code snippet Region block: start -> # Region /snippetname/, end -> # End Region
-// const VBCodeSnippetRegionRegionStartLineTemplate = /#region{tagname}/g;
+// const VBCodeSnippetRegionRegionStartLineTemplate = /#region {tagname}/g;
 // const VBCodeSnippetRegionRegionEndLineTemplate = /#endregion/g;
 
 // // XML code snippet block: <!-- <[/]snippetname> -->
@@ -111,12 +116,14 @@ const dict = [
   // { xml: ["xsl", "xslt", "xsd", "wsdl", ".xml", ".csdl", ".edmx", ".xsl", ".xslt", ".xsd", ".wsdl"] },
   // { vb: ["vbnet", "vbscript", ".vb", ".bas", ".vbs", ".vba"] }
 ]
-
+let codeSnippetContent = "";
+let firstIteration = true;
 export const TRIPLE_COLON_CODE_RE = /:::(\s+)?code\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"(\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"(\s+)?)?:::/g;
 export function tripleColonCodeSnippets(md, options) {
-  const replaceTripleColonCodeSnippetWithContents = (src: string, rootdir: string) => {
+  const replaceTripleColonCodeSnippetWithContents = async (src: string, rootdir: string) => {
     // let captureGroup;
     const matches = src.match(TRIPLE_COLON_CODE_RE);
+
     for (const match of matches) {
       const position = src.indexOf(match);
       // while ((captureGroup = TRIPLE_COLON_CODE_RE.exec(src))) {
@@ -133,165 +140,211 @@ export function tripleColonCodeSnippets(md, options) {
       }
       let output = "";
       const lineArr: string[] = [];
-
-      let filePath = resolve(rootdir, source[1].trim());
-      if (filePath.includes("~")) {
-        filePath = filePath.replace(ROOTPATH_RE, repoRoot);
-      }
-      const data = readFileSync(filePath, "utf8")
-        .split("\n")
-        .filter(Boolean);
-      const RANGE_RE = /range="(.*?)"/g;
-      // const range = RANGE_RE.exec(captureGroup[0]);
-      const range = RANGE_RE.exec(match);
-      const ID_RE = /id="(.*?)"/g;
-      // const idMatch = ID_RE.exec(captureGroup[0]);
-      const idMatch = ID_RE.exec(match);
-      if (idMatch) {
-        const id = idMatch[1].trim();
-        let startLine = 0;
-        let endLine = 0;
-        let START_RE
-        let START_SPACE_RE
-        let END_RE
-        let END_SPACE_RE
-        // logic for id.
-        // get language to know what type of comment to expect
-        switch (language) {
-          case "cpp":
-          case "vb":
-          case "java":
-          case "javascript":
-          case "js":
-          case "fsharp":
-          case "typescript":
-          case "go":
-          case "php":
-          case "rust":
-          case "objectivec":
-            START_RE = new RegExp(`\/\/<${id}>`)
-            START_SPACE_RE = new RegExp(`\/\/ <${id}>`);;
-            END_RE = new RegExp(`\/\/<\/${id}>`)
-            END_SPACE_RE = new RegExp(`\/\/ <\/${id}>`);
-            break;
-          case "cs":
-          case "csharp":
-            START_RE = new RegExp(`#region${id}`)
-            START_SPACE_RE = new RegExp(`#region ${id}`);
-            END_RE = new RegExp(`#endregion`);
-            END_SPACE_RE = new RegExp(`#endregion`);
-            break;
-          case "xml":
-          case "html":
-            START_RE = new RegExp(`<!--<${id}>-->`)
-            START_SPACE_RE = new RegExp(`<!-- <${id}> -->`)
-            END_RE = new RegExp(`<!--<\/${id}>-->`)
-            END_SPACE_RE = new RegExp(`<!-- </${id}> -->`)
-            break;
-          case "sql":
-            START_RE = new RegExp(`--<${id}>`)
-            START_SPACE_RE = new RegExp(`-- <${id}>`);
-            END_RE = new RegExp(`-- <\/${id}>`)
-            END_SPACE_RE = new RegExp(`--<\/${id}>`);
-            break;
-          case "python":
-          case "powershell":
-          case "shell":
-          case "ruby":
-            START_RE = new RegExp(`#<${id}>`);
-            START_SPACE_RE = new RegExp(`# <${id}>`);
-            END_RE = new RegExp(`#<\/${id}>`);
-            END_SPACE_RE = new RegExp(`# <\/${id}>`);
-            break;
-          case "batchfile":
-            START_RE = new RegExp(`rem<${id}>`, "i");
-            START_SPACE_RE = new RegExp(`rem <${id}>`, "i");
-            END_RE = new RegExp(`rem<\/${id}>`, "i");
-            END_SPACE_RE = new RegExp(`rem <\/${id}>`, "i");
-            break;
-          case "erlang":
-            START_RE = new RegExp(`%<${id}>`);
-            START_SPACE_RE = new RegExp(`% <${id}>`);
-            END_RE = new RegExp(`%</${id}>`);
-            END_SPACE_RE = new RegExp(`% </${id}>`);
-            break;
-          case "lisp":
-            START_RE = new RegExp(`;<${id}>`);
-            START_SPACE_RE = new RegExp(`; <${id}>`);
-            END_RE = new RegExp(`;</${id}>`);
-            END_SPACE_RE = new RegExp(`; </${id}>`);
-            break;
-          default:
-            // get all lines
-            startLine = 0;
-            endLine = data.length;
-            break;
-        }
-        for (let index = 0; index < data.length; index++) {
-          if (START_RE.exec(data[index])) {
-            startLine = index;
-          } else if (START_SPACE_RE.exec(data[index])) {
-            startLine = index;
-          }
-          if (END_RE.exec(data[index])) {
-            endLine = index;
-            break;
-          } else if (END_SPACE_RE.exec(data[index])) {
-            endLine = index;
-            break;
-          }
-          if (index + 1 === data.length) {
-            endLine = data.length;
-            break;
-          }
-        }
-        data.map((x, index) => {
-          if (index > startLine && index < endLine) {
-            lineArr.push(x);
-          }
-        })
-        output = lineArr.join("\n");
-      } else if (range) {
-
-        const rangeArr: number[] = [];
-        const rangeList = range[1].split(",");
-        rangeList.forEach((element) => {
-          if (element.indexOf("-") > 0) {
-            const rangeThru = element.split("-");
-            const startRange = parseInt(rangeThru[0], 10);
-            const endRange = parseInt(rangeThru.pop(), 10);
-            for (let index = startRange; index <= endRange; index++) {
-              rangeArr.push(index);
-            }
-          } else {
-            rangeArr.push(parseInt(element, 10));
-          }
-        });
-        rangeArr.sort();
-        data.map((line, index) => {
-          rangeArr.filter((x) => {
-            if (x === index + 1) {
-              lineArr.push(line);
+      let file
+      let filePath = resolve(repoRoot, source[1].trim());
+      let path = source[1].trim();
+      if (path.includes("~")) {
+        // get openpublishing.json
+        let position = 0
+        let repoPath = "";
+        const openPublishingFilePath = resolve(repoRoot, ".openpublishing.publish.config.json")
+        const openPublishingFile = await readFile(openPublishingFilePath, "utf8")
+        // filePath = filePath.replace(ROOTPATH_RE, repoRoot);
+        const openPublishingJson = JSON.parse(openPublishingFile)
+        const repos = openPublishingJson["dependent_repositories"]
+        const parts = path.split("/")
+        if (repos) {
+          repos.map(repo => {
+            if (parts) {
+              parts.map((part, index) => {
+                if (repo.path_to_root === part) {
+                  position = index;
+                  repoPath = repo.url;
+                  return;
+                }
+              });
             }
           });
-        });
-        output = lineArr.join("\n");
+          path = buildRepoPath(repoPath, position, parts)
+        }
+        const apiUrl = path;
+        try {
+          await Axios.get(apiUrl)
+            .then(response => {
+              if (response) {
+                file = Base64.decode(response.data.content);
+              }
+            });
+        } catch (error) {
+          outputChannel.appendLine(error);
+        }
       } else {
-        output = readFileSync(filePath, "utf8");
+        file = await readFile(filePath, "utf8")
       }
-      output = `\`\`\`${language}\r\n${output}\r\n\`\`\``;
-      src = src.slice(0, position) + output + src.slice(position + match.length, src.length);
-      // src = src.slice(0, captureGroup.index) + output + src.slice(captureGroup.index + captureGroup[0].length, src.length);
-      // }
+
+      if (file) {
+        const data = file.split("\n");
+        const RANGE_RE = /range="(.*?)"/g;
+        // const range = RANGE_RE.exec(captureGroup[0]);
+        const range = RANGE_RE.exec(match);
+        const ID_RE = /id="(.*?)"/g;
+        // const idMatch = ID_RE.exec(captureGroup[0]);
+        const idMatch = ID_RE.exec(match);
+        if (idMatch) {
+          const id = idMatch[1].trim();
+          let startLine = 0;
+          let endLine = 0;
+          let START_RE
+          let START_SPACE_RE
+          let END_RE
+          let END_SPACE_RE
+          // logic for id.
+          // get language to know what type of comment to expect
+          switch (language) {
+            case "cpp":
+            case "vb":
+            case "java":
+            case "javascript":
+            case "js":
+            case "fsharp":
+            case "typescript":
+            case "go":
+            case "php":
+            case "rust":
+            case "objectivec":
+              START_RE = new RegExp(`\/\/<${id}>`)
+              START_SPACE_RE = new RegExp(`\/\/ <${id}>`);;
+              END_RE = new RegExp(`\/\/<\/${id}>`)
+              END_SPACE_RE = new RegExp(`\/\/ <\/${id}>`);
+              break;
+            case "cs":
+            case "csharp":
+              START_RE = new RegExp(`#region${id}`)
+              START_SPACE_RE = new RegExp(`#region ${id}`);
+              END_RE = new RegExp(`#endregion`);
+              END_SPACE_RE = new RegExp(`#endregion`);
+              break;
+            case "xml":
+            case "html":
+              START_RE = new RegExp(`<!--<${id}>-->`)
+              START_SPACE_RE = new RegExp(`<!-- <${id}> -->`)
+              END_RE = new RegExp(`<!--<\/${id}>-->`)
+              END_SPACE_RE = new RegExp(`<!-- </${id}> -->`)
+              break;
+            case "sql":
+              START_RE = new RegExp(`--<${id}>`)
+              START_SPACE_RE = new RegExp(`-- <${id}>`);
+              END_RE = new RegExp(`-- <\/${id}>`)
+              END_SPACE_RE = new RegExp(`--<\/${id}>`);
+              break;
+            case "python":
+            case "powershell":
+            case "shell":
+            case "ruby":
+              START_RE = new RegExp(`#<${id}>`);
+              START_SPACE_RE = new RegExp(`# <${id}>`);
+              END_RE = new RegExp(`#<\/${id}>`);
+              END_SPACE_RE = new RegExp(`# <\/${id}>`);
+              break;
+            case "batchfile":
+              START_RE = new RegExp(`rem<${id}>`, "i");
+              START_SPACE_RE = new RegExp(`rem <${id}>`, "i");
+              END_RE = new RegExp(`rem<\/${id}>`, "i");
+              END_SPACE_RE = new RegExp(`rem <\/${id}>`, "i");
+              break;
+            case "erlang":
+              START_RE = new RegExp(`%<${id}>`);
+              START_SPACE_RE = new RegExp(`% <${id}>`);
+              END_RE = new RegExp(`%</${id}>`);
+              END_SPACE_RE = new RegExp(`% </${id}>`);
+              break;
+            case "lisp":
+              START_RE = new RegExp(`;<${id}>`);
+              START_SPACE_RE = new RegExp(`; <${id}>`);
+              END_RE = new RegExp(`;</${id}>`);
+              END_SPACE_RE = new RegExp(`; </${id}>`);
+              break;
+            default:
+              // get all lines
+              startLine = 0;
+              endLine = data.length;
+              break;
+          }
+          for (let index = 0; index < data.length; index++) {
+            if (START_RE.exec(data[index])) {
+              startLine = index;
+            } else if (START_SPACE_RE.exec(data[index])) {
+              startLine = index;
+            }
+            if (END_RE.exec(data[index])) {
+              endLine = index;
+              break;
+            } else if (END_SPACE_RE.exec(data[index])) {
+              endLine = index;
+              break;
+            }
+            if (index + 1 === data.length) {
+              endLine = data.length;
+              break;
+            }
+          }
+          data.map((x, index) => {
+            if (index > startLine && index < endLine) {
+              lineArr.push(x);
+            }
+          })
+          output = lineArr.join("\n");
+
+        } else if (range) {
+
+          const rangeArr: number[] = [];
+          const rangeList = range[1].split(",");
+          rangeList.forEach((element) => {
+            if (element.indexOf("-") > 0) {
+              const rangeThru = element.split("-");
+              const startRange = parseInt(rangeThru[0], 10);
+              const endRange = parseInt(rangeThru.pop(), 10);
+              for (let index = startRange; index <= endRange; index++) {
+                rangeArr.push(index);
+              }
+            } else {
+              rangeArr.push(parseInt(element, 10));
+            }
+          });
+          rangeArr.sort();
+          data.map((line, index) => {
+            rangeArr.filter((x) => {
+              if (x === index + 1) {
+                lineArr.push(line);
+              }
+            });
+          });
+          output = lineArr.join("\n");
+        } else {
+          output = readFileSync(filePath, "utf8");
+        }
+        output = `\`\`\`${language}\r\n${output}\r\n\`\`\``;
+        src = src.slice(0, position) + output + src.slice(position + match.length, src.length);
+        // src = src.slice(0, captureGroup.index) + output + src.slice(captureGroup.index + captureGroup[0].length, src.length);
+        // }
+        codeSnippetContent = src;
+        const matchesRemaining = codeSnippetContent.match(TRIPLE_COLON_CODE_RE);
+        if (matchesRemaining) {
+          if (firstIteration) {
+            firstIteration = false;
+            updateEditorToRefreshChanges();
+          }
+        }
+      }
     }
-    return src;
   };
 
   const importTripleColonCodeSnippets = (state) => {
     try {
-      state.src = replaceTripleColonCodeSnippetWithContents(state.src, options.root);
+      replaceTripleColonCodeSnippetWithContents(state.src, options.root);
+      state.src = codeSnippetContent;
     } catch (error) {
-      output.appendLine(error);
+      outputChannel.appendLine(error);
     }
   };
   md.core.ruler.before("normalize", "codesnippet", importTripleColonCodeSnippets);
@@ -309,4 +362,16 @@ function updateEditorToRefreshChanges() {
       update.delete(range);
     })
   });
+}
+
+function buildRepoPath(repo, position, parts) {
+  let fullPath = [];
+  repo = repo.replace("https://github.com/", "https://api.github.com/repos/")
+  fullPath.push(repo);
+  fullPath.push("contents")
+  for (let index = position + 1; index < parts.length; index++) {
+    const path = parts[index];
+    fullPath.push(path);
+  }
+  return fullPath.join("/");
 }

--- a/docs-preview/src/markdown-extensions/codesnippet.ts
+++ b/docs-preview/src/markdown-extensions/codesnippet.ts
@@ -1,9 +1,7 @@
 import { resolve } from "path";
-import { readFileSync, createReadStream } from "fs";
+import { readFileSync } from "fs";
 import { output } from "../extension";
-import { workspace } from "vscode";
-import { createInterface } from "readline"
-import * as reader from "readline-sync";
+import { workspace, window, Position } from "vscode";
 
 export const CODE_RE = /\[!code-(.+?)\s*\[\s*.+?\s*]\(\s*(.+?)\s*\)\s*]/i;
 const ROOTPATH_RE = /.*~/gmi;
@@ -33,6 +31,85 @@ export function codeSnippets(md, options) {
   md.core.ruler.before("normalize", "codesnippet", importCodeSnippet);
 }
 
+// C# code snippet comment block: // <[/]snippetname>
+const CFamilyCodeSnippetCommentStartLineTemplate = /\/\/<{tagname}>/g;
+const CFamilyCodeSnippetCommentEndLineTemplate = /\/\/<\/{tagname}>/g;
+
+// C# code snippet region block: start -> #region snippetname, end -> #endregion
+const CSharpCodeSnippetRegionStartLineTemplate = /#region{tagname}/g;
+const CSharpCodeSnippetRegionEndLineTemplate = /#endregion/g;
+
+// VB code snippet comment block: ' <[/]snippetname>
+const BasicFamilyCodeSnippetCommentStartLineTemplate = /'<{tagname}>/g;
+const BasicFamilyCodeSnippetCommentEndLineTemplate = /'<\/{tagname}>/g;
+
+// VB code snippet Region block: start -> # Region /snippetname/, end -> # End Region
+const VBCodeSnippetRegionRegionStartLineTemplate = /#region{tagname}/g;
+const VBCodeSnippetRegionRegionEndLineTemplate = /#endregion/g;
+
+// XML code snippet block: <!-- <[/]snippetname> -->
+const MarkupLanguageFamilyCodeSnippetCommentStartLineTemplate = /<!--<{tagname}>-->/g;
+const MarkupLanguageFamilyCodeSnippetCommentEndLineTemplate = /<!--<\/{tagname}>-->/g;
+
+// Sql code snippet block: -- <[/]snippetname>
+const SqlFamilyCodeSnippetCommentStartLineTemplate = /--<{tagname}>/g;
+const SqlFamilyCodeSnippetCommentEndLineTemplate = /--<\/{tagname}>/g;
+
+// Python code snippet comment block: # <[/]snippetname>
+const ScriptFamilyCodeSnippetCommentStartLineTemplate = /#<{tagname}>/g;
+const ScriptFamilyCodeSnippetCommentEndLineTemplate = /#<\/{tagname}>/g;
+
+// Batch code snippet comment block: rem <[/]snippetname>
+const BatchFileCodeSnippetRegionStartLineTemplate = /rem<{tagname}>/g;
+const BatchFileCodeSnippetRegionEndLineTemplate = /rem<\/{tagname}>/g;
+
+// Erlang code snippet comment block: % <[/]snippetname>
+const ErlangCodeSnippetRegionStartLineTemplate = /%<{tagname}>/g;
+const ErlangCodeSnippetRegionEndLineTemplate = /%<{tagname}>/g;
+
+// Lisp code snippet comment block: ; <[/]snippetname>
+const LispCodeSnippetRegionStartLineTemplate = /;<{tagname}>/g;
+const LispCodeSnippetRegionEndLineTemplate = /;<{tagname}>/g;
+const dict = [
+  { actionscript: [".as"] },
+  { arduino: [".ino"] },
+  { assembly: ["nasm", ".asm"] },
+  { batchfile: [".bat", ".cmd"] },
+  { cpp: ["c", "c++", "objective-c", "obj-c", "objc", "objectivec", ".c", ".cpp", ".h", ".hpp", ".cc"] },
+  { csharp: ["cs", ".cs"] },
+  { cuda: [".cu", ".cuh"] },
+  { d: ["dlang", ".d"] },
+  { erlang: [".erl"] },
+  { fsharp: ["fs", ".fs", ".fsi", ".fsx"] },
+  { go: ["golang", ".go"] },
+  { haskell: [".hs"] },
+  { html: [".html", ".jsp", ".asp", ".aspx", ".ascx"] },
+  { cshtml: [".cshtml", "aspx-cs", "aspx-csharp"] },
+  { vbhtml: [".vbhtml", "aspx-vb"] },
+  { java: [".java"] },
+  { javascript: ["js", "node", ".js"] },
+  { lisp: [".lisp", ".lsp"] },
+  { lua: [".lua"] },
+  { matlab: [".matlab"] },
+  { pascal: [".pas"] },
+  { perl: [".pl"] },
+  { php: [".php"] },
+  { powershell: ["posh", ".ps1"] },
+  { processing: [".pde"] },
+  { python: [".py"] },
+  { r: [".r"] },
+  { ruby: ["ru", ".ru", ".ruby"] },
+  { rust: [".rs"] },
+  { scala: [".scala"] },
+  { shell: ["sh", "bash", ".sh", ".bash"] },
+  { smalltalk: [".st"] },
+  { sql: [".sql"] },
+  { swift: [".swift"] },
+  { typescript: ["ts", ".ts"] },
+  { xaml: [".xaml"] },
+  { xml: ["xsl", "xslt", "xsd", "wsdl", ".xml", ".csdl", ".edmx", ".xsl", ".xslt", ".xsd", ".wsdl"] },
+  { vb: ["vbnet", "vbscript", ".vb", ".bas", ".vbs", ".vba"] }]
+
 export const TRIPLE_COLON_CODE_RE = /:::(\s+)?code\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"\s+((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?")?(\s+)?:::/i;
 export function tripleColonCodeSnippets(md, options) {
   const replaceTripleColonCodeSnippetWithContents = (src: string, rootdir: string) => {
@@ -42,22 +119,71 @@ export function tripleColonCodeSnippets(md, options) {
       const SOURCE_RE = /source="(.*?)"/g;
       const source = SOURCE_RE.exec(captureGroup[0]);
       const LANGUAGE_RE = /language="(.*?)"/g;
-      const language = LANGUAGE_RE.exec(captureGroup[0]);
+      let languageMatch = LANGUAGE_RE.exec(captureGroup[0]);
+      let language = ""
+      if (languageMatch) {
+        language = languageMatch[1].trim()
+      }
       let output = "";
+      const lineArr: string[] = [];
+
       let filePath = resolve(rootdir, source[1].trim());
       if (filePath.includes("~")) {
-
         filePath = filePath.replace(ROOTPATH_RE, repoRoot);
       }
-      let mdSrc = readFileSync(filePath, "utf8")
-        .split('\n')
+      const data = readFileSync(filePath, "utf8")
+        .split("\n")
         .filter(Boolean);
       const RANGE_RE = /range="(.*?)"/g;
       const range = RANGE_RE.exec(captureGroup[0]);
       const ID_RE = /id="(.*?)"/g;
-      const id = ID_RE.exec(captureGroup[0]);
-      const rangeArr: number[] = [];
-      if (range) {
+      const idMatch = ID_RE.exec(captureGroup[0]);
+      if (idMatch) {
+        const id = idMatch[1].trim();
+        let startLine = 0;
+        let endLine = 0;
+        // logic for id.
+        // get language to know what type of comment to expect
+        switch (language) {
+          case "cpp":
+            data.map((x, index) => {
+              const startMatch = new RegExp(`\/\/<${id}>`).exec(x);
+              if (startMatch) {
+                startLine = index;
+              }
+              const endMatch = new RegExp(`\/\/<\/${id}>`).exec(x);
+              if (endMatch) {
+                endLine = index;
+                return;
+              }
+            });
+            break;
+          case "cs":
+            data.map((x, index) => {
+              const startMatch = new RegExp(`#region${id}`).exec(x);
+              if (startMatch) {
+                startLine = index;
+              }
+              const endMatch = new RegExp(`#endregion`).exec(x);
+              if (endMatch) {
+                endLine = index;
+                return;
+              }
+            });
+            break;
+
+          default:
+            break;
+        }
+        data.map((x, index) => {
+          if (index > startLine && index < endLine) {
+            lineArr.push(x);
+          }
+        })
+        output = lineArr.join("\n");
+      } else if (range) {
+
+        const rangeArr: number[] = [];
         const rangeList = range[1].split(",");
         rangeList.forEach((element) => {
           if (element.indexOf("-") > 0) {
@@ -72,22 +198,18 @@ export function tripleColonCodeSnippets(md, options) {
           }
         });
         rangeArr.sort();
-        const lineArr: string[] = [];
-        mdSrc.map((line, index) => {
-          rangeArr.filter(x => {
-            var thing = x === index + 1
-            if (thing) {
+        data.map((line, index) => {
+          rangeArr.filter((x) => {
+            if (x === index + 1) {
               lineArr.push(line);
             }
-          })
+          });
         });
         output = lineArr.join("\n");
-      } else if (id) {
-        // logic for id.
       } else {
-        output = readFileSync(filePath, "utf8")
+        output = readFileSync(filePath, "utf8");
       }
-      output = `\`\`\`${language[1].trim()}\r\n${output}\r\n\`\`\``;
+      output = `\`\`\`${language}\r\n${output}\r\n\`\`\``;
       src = src.slice(0, captureGroup.index) + output + src.slice(captureGroup.index + captureGroup[0].length, src.length);
     }
     return src;
@@ -122,4 +244,18 @@ export function custom_codeblock(md, options) {
     }
   };
   md.core.ruler.before("normalize", "custom_codeblock", customCodeBlock);
+}
+
+function updateEditorToRefreshChanges() {
+  const editor = window.activeTextEditor;
+  const lastLine = editor.document.lineAt(editor.document.lineCount - 1);
+  const position = new Position(editor.document.lineCount - 1, lastLine.range.end.character);
+  editor.edit((update) => {
+    update.insert(position, " ");
+  }).then(() => {
+    editor.edit((update) => {
+      const range = editor.document.getWordRangeAtPosition(position, /[ ]+/g);
+      update.delete(range);
+    })
+  });
 }

--- a/docs-preview/src/markdown-extensions/codesnippet.ts
+++ b/docs-preview/src/markdown-extensions/codesnippet.ts
@@ -249,6 +249,7 @@ function rangeToOutput(lineArr, data, range) {
       }
     });
   });
+  lineArr = dedent(lineArr);
   return lineArr.join("\n");
 }
 
@@ -277,5 +278,46 @@ function idToOutput(idMatch, lineArr, data, language) {
       lineArr.push(x);
     }
   });
+  lineArr = dedent(lineArr);
   return lineArr.join("\n");
+}
+
+function dedent(lineArr) {
+  let indent = 0;
+  let firstIteration = true;
+  for (const key in lineArr) {
+    if (lineArr.hasOwnProperty(key)) {
+      let index = 0;
+      const line = lineArr[key].split("");
+      for (const val in line) {
+        if (line.hasOwnProperty(val)) {
+          const character = line[val];
+          if (firstIteration) {
+            if (!/\s/.test(character)) {
+              lineArr[key] = lineArr[key].substring(indent);
+              break;
+            } else {
+              indent++;
+            }
+          } else {
+            // check if all spaces
+            const allSpaces = lineArr[key].substring(0, indent)
+            if (allSpaces.match(/^ *$/) !== null) {
+              lineArr[key] = lineArr[key].substring(indent);
+              break;
+            } else {
+              if (!/\s/.test(character)) {
+                lineArr[key] = lineArr[key].substring(index);
+                break;
+              }
+
+            }
+          }
+          index++;
+        }
+      }
+      firstIteration = false;
+    }
+  }
+  return lineArr;
 }

--- a/docs-preview/src/markdown-extensions/codesnippet.ts
+++ b/docs-preview/src/markdown-extensions/codesnippet.ts
@@ -225,27 +225,6 @@ export function tripleColonCodeSnippets(md, options) {
   md.core.ruler.before("normalize", "codesnippet", importTripleColonCodeSnippets);
 }
 
-
-export function custom_codeblock(md, options) {
-  const CODEBLOCK_RE = /([ ]{5})/g;
-  const removeCodeblockSpaces = (src: string) => {
-    let captureGroup;
-    while ((captureGroup = CODEBLOCK_RE.exec(src))) {
-      src = src.slice(0, captureGroup.index) + src.slice(captureGroup.index + captureGroup[0].length, src.length);
-    }
-    return src;
-  };
-
-  const customCodeBlock = (state) => {
-    try {
-      state.src = removeCodeblockSpaces(state.src);
-    } catch (error) {
-      output.appendLine(error);
-    }
-  };
-  md.core.ruler.before("normalize", "custom_codeblock", customCodeBlock);
-}
-
 function updateEditorToRefreshChanges() {
   const editor = window.activeTextEditor;
   const lastLine = editor.document.lineAt(editor.document.lineCount - 1);

--- a/docs-preview/src/markdown-extensions/codesnippet.ts
+++ b/docs-preview/src/markdown-extensions/codesnippet.ts
@@ -31,95 +31,102 @@ export function codeSnippets(md, options) {
   md.core.ruler.before("normalize", "codesnippet", importCodeSnippet);
 }
 
-// C# code snippet comment block: // <[/]snippetname>
-const CFamilyCodeSnippetCommentStartLineTemplate = /\/\/<{tagname}>/g;
-const CFamilyCodeSnippetCommentEndLineTemplate = /\/\/<\/{tagname}>/g;
+// // C# code snippet comment block: // <[/]snippetname>
+// const CFamilyCodeSnippetCommentStartLineTemplate = /\/\/<{tagname}>/g;
+// const CFamilyCodeSnippetCommentEndLineTemplate = /\/\/<\/{tagname}>/g;
 
-// C# code snippet region block: start -> #region snippetname, end -> #endregion
-const CSharpCodeSnippetRegionStartLineTemplate = /#region{tagname}/g;
-const CSharpCodeSnippetRegionEndLineTemplate = /#endregion/g;
+// // C# code snippet region block: start -> #region snippetname, end -> #endregion
+// const CSharpCodeSnippetRegionStartLineTemplate = /#region{tagname}/g;
+// const CSharpCodeSnippetRegionEndLineTemplate = /#endregion/g;
 
-// VB code snippet comment block: ' <[/]snippetname>
-const BasicFamilyCodeSnippetCommentStartLineTemplate = /'<{tagname}>/g;
-const BasicFamilyCodeSnippetCommentEndLineTemplate = /'<\/{tagname}>/g;
+// // VB code snippet comment block: ' <[/]snippetname>
+// const BasicFamilyCodeSnippetCommentStartLineTemplate = /'<{tagname}>/g;
+// const BasicFamilyCodeSnippetCommentEndLineTemplate = /'<\/{tagname}>/g;
 
-// VB code snippet Region block: start -> # Region /snippetname/, end -> # End Region
-const VBCodeSnippetRegionRegionStartLineTemplate = /#region{tagname}/g;
-const VBCodeSnippetRegionRegionEndLineTemplate = /#endregion/g;
+// // VB code snippet Region block: start -> # Region /snippetname/, end -> # End Region
+// const VBCodeSnippetRegionRegionStartLineTemplate = /#region{tagname}/g;
+// const VBCodeSnippetRegionRegionEndLineTemplate = /#endregion/g;
 
-// XML code snippet block: <!-- <[/]snippetname> -->
-const MarkupLanguageFamilyCodeSnippetCommentStartLineTemplate = /<!--<{tagname}>-->/g;
-const MarkupLanguageFamilyCodeSnippetCommentEndLineTemplate = /<!--<\/{tagname}>-->/g;
+// // XML code snippet block: <!-- <[/]snippetname> -->
+// const MarkupLanguageFamilyCodeSnippetCommentStartLineTemplate = /<!--<{tagname}>-->/g;
+// const MarkupLanguageFamilyCodeSnippetCommentEndLineTemplate = /<!--<\/{tagname}>-->/g;
 
-// Sql code snippet block: -- <[/]snippetname>
-const SqlFamilyCodeSnippetCommentStartLineTemplate = /--<{tagname}>/g;
-const SqlFamilyCodeSnippetCommentEndLineTemplate = /--<\/{tagname}>/g;
+// // Sql code snippet block: -- <[/]snippetname>
+// const SqlFamilyCodeSnippetCommentStartLineTemplate = /--<{tagname}>/g;
+// const SqlFamilyCodeSnippetCommentEndLineTemplate = /--<\/{tagname}>/g;
 
-// Python code snippet comment block: # <[/]snippetname>
-const ScriptFamilyCodeSnippetCommentStartLineTemplate = /#<{tagname}>/g;
-const ScriptFamilyCodeSnippetCommentEndLineTemplate = /#<\/{tagname}>/g;
+// // Python code snippet comment block: # <[/]snippetname>
+// const ScriptFamilyCodeSnippetCommentStartLineTemplate = /#<{tagname}>/g;
+// const ScriptFamilyCodeSnippetCommentEndLineTemplate = /#<\/{tagname}>/g;
 
-// Batch code snippet comment block: rem <[/]snippetname>
-const BatchFileCodeSnippetRegionStartLineTemplate = /rem<{tagname}>/g;
-const BatchFileCodeSnippetRegionEndLineTemplate = /rem<\/{tagname}>/g;
+// // Batch code snippet comment block: rem <[/]snippetname>
+// const BatchFileCodeSnippetRegionStartLineTemplate = /rem<{tagname}>/g;
+// const BatchFileCodeSnippetRegionEndLineTemplate = /rem<\/{tagname}>/g;
 
-// Erlang code snippet comment block: % <[/]snippetname>
-const ErlangCodeSnippetRegionStartLineTemplate = /%<{tagname}>/g;
-const ErlangCodeSnippetRegionEndLineTemplate = /%<{tagname}>/g;
+// // Erlang code snippet comment block: % <[/]snippetname>
+// const ErlangCodeSnippetRegionStartLineTemplate = /%<{tagname}>/g;
+// const ErlangCodeSnippetRegionEndLineTemplate = /%<{tagname}>/g;
 
-// Lisp code snippet comment block: ; <[/]snippetname>
-const LispCodeSnippetRegionStartLineTemplate = /;<{tagname}>/g;
-const LispCodeSnippetRegionEndLineTemplate = /;<{tagname}>/g;
+// // Lisp code snippet comment block: ; <[/]snippetname>
+// const LispCodeSnippetRegionStartLineTemplate = /;<{tagname}>/g;
+// const LispCodeSnippetRegionEndLineTemplate = /;<{tagname}>/g;
+
 const dict = [
   { actionscript: [".as"] },
   { arduino: [".ino"] },
   { assembly: ["nasm", ".asm"] },
-  { batchfile: [".bat", ".cmd"] },
-  { cpp: ["c", "c++", "objective-c", "obj-c", "objc", "objectivec", ".c", ".cpp", ".h", ".hpp", ".cc"] },
-  { csharp: ["cs", ".cs"] },
+  // { batchfile: [".bat", ".cmd"] },
+  // { cpp: ["c", "c++", "objective-c", "obj-c", "objc", "objectivec", ".c", ".cpp", ".h", ".hpp", ".cc"] },
+  // { csharp: ["cs", ".cs"] },
   { cuda: [".cu", ".cuh"] },
   { d: ["dlang", ".d"] },
-  { erlang: [".erl"] },
-  { fsharp: ["fs", ".fs", ".fsi", ".fsx"] },
-  { go: ["golang", ".go"] },
+  // { erlang: [".erl"] },
+  // { fsharp: ["fs", ".fs", ".fsi", ".fsx"] },
+  // { go: ["golang", ".go"] },
   { haskell: [".hs"] },
-  { html: [".html", ".jsp", ".asp", ".aspx", ".ascx"] },
+  // { html: [".html", ".jsp", ".asp", ".aspx", ".ascx"] },
   { cshtml: [".cshtml", "aspx-cs", "aspx-csharp"] },
   { vbhtml: [".vbhtml", "aspx-vb"] },
-  { java: [".java"] },
-  { javascript: ["js", "node", ".js"] },
-  { lisp: [".lisp", ".lsp"] },
+  // { java: [".java"] },
+  // { javascript: ["js", "node", ".js"] },
+  // { lisp: [".lisp", ".lsp"] },
   { lua: [".lua"] },
   { matlab: [".matlab"] },
   { pascal: [".pas"] },
   { perl: [".pl"] },
-  { php: [".php"] },
-  { powershell: ["posh", ".ps1"] },
+  // { php: [".php"] },
+  // { powershell: ["posh", ".ps1"] },
   { processing: [".pde"] },
-  { python: [".py"] },
+  // { python: [".py"] },
   { r: [".r"] },
-  { ruby: ["ru", ".ru", ".ruby"] },
-  { rust: [".rs"] },
+  // { ruby: ["ru", ".ru", ".ruby"] },
+  // { rust: [".rs"] },
   { scala: [".scala"] },
-  { shell: ["sh", "bash", ".sh", ".bash"] },
+  // { shell: ["sh", "bash", ".sh", ".bash"] },
   { smalltalk: [".st"] },
-  { sql: [".sql"] },
+  // { sql: [".sql"] },
   { swift: [".swift"] },
-  { typescript: ["ts", ".ts"] },
+  // { typescript: ["ts", ".ts"] },
   { xaml: [".xaml"] },
-  { xml: ["xsl", "xslt", "xsd", "wsdl", ".xml", ".csdl", ".edmx", ".xsl", ".xslt", ".xsd", ".wsdl"] },
-  { vb: ["vbnet", "vbscript", ".vb", ".bas", ".vbs", ".vba"] }]
+  // { xml: ["xsl", "xslt", "xsd", "wsdl", ".xml", ".csdl", ".edmx", ".xsl", ".xslt", ".xsd", ".wsdl"] },
+  // { vb: ["vbnet", "vbscript", ".vb", ".bas", ".vbs", ".vba"] }
+]
 
-export const TRIPLE_COLON_CODE_RE = /:::(\s+)?code\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"\s+((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?")?(\s+)?:::/i;
+export const TRIPLE_COLON_CODE_RE = /:::(\s+)?code\s+(source|range|id|highlight|language|interactive)=".*?"\s+(source|range|id|highlight|language|interactive)=".*?"(\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"\s+)?((source|range|id|highlight|language|interactive)=".*?"(\s+)?)?:::/g;
 export function tripleColonCodeSnippets(md, options) {
   const replaceTripleColonCodeSnippetWithContents = (src: string, rootdir: string) => {
-    let captureGroup;
-    while ((captureGroup = TRIPLE_COLON_CODE_RE.exec(src))) {
+    // let captureGroup;
+    const matches = src.match(TRIPLE_COLON_CODE_RE);
+    for (const match of matches) {
+      const position = src.indexOf(match);
+      // while ((captureGroup = TRIPLE_COLON_CODE_RE.exec(src))) {
       const repoRoot = workspace.workspaceFolders[0].uri.fsPath;
       const SOURCE_RE = /source="(.*?)"/g;
-      const source = SOURCE_RE.exec(captureGroup[0]);
+      // const source = SOURCE_RE.exec(captureGroup[0]);
+      const source = SOURCE_RE.exec(match);
       const LANGUAGE_RE = /language="(.*?)"/g;
-      let languageMatch = LANGUAGE_RE.exec(captureGroup[0]);
+      // let languageMatch = LANGUAGE_RE.exec(captureGroup[0]);
+      let languageMatch = LANGUAGE_RE.exec(match);
       let language = ""
       if (languageMatch) {
         language = languageMatch[1].trim()
@@ -135,45 +142,108 @@ export function tripleColonCodeSnippets(md, options) {
         .split("\n")
         .filter(Boolean);
       const RANGE_RE = /range="(.*?)"/g;
-      const range = RANGE_RE.exec(captureGroup[0]);
+      // const range = RANGE_RE.exec(captureGroup[0]);
+      const range = RANGE_RE.exec(match);
       const ID_RE = /id="(.*?)"/g;
-      const idMatch = ID_RE.exec(captureGroup[0]);
+      // const idMatch = ID_RE.exec(captureGroup[0]);
+      const idMatch = ID_RE.exec(match);
       if (idMatch) {
         const id = idMatch[1].trim();
         let startLine = 0;
         let endLine = 0;
+        let START_RE
+        let START_SPACE_RE
+        let END_RE
+        let END_SPACE_RE
         // logic for id.
         // get language to know what type of comment to expect
         switch (language) {
           case "cpp":
-            data.map((x, index) => {
-              const startMatch = new RegExp(`\/\/<${id}>`).exec(x);
-              if (startMatch) {
-                startLine = index;
-              }
-              const endMatch = new RegExp(`\/\/<\/${id}>`).exec(x);
-              if (endMatch) {
-                endLine = index;
-                return;
-              }
-            });
+          case "vb":
+          case "java":
+          case "javascript":
+          case "js":
+          case "fsharp":
+          case "typescript":
+          case "go":
+          case "php":
+          case "rust":
+          case "objectivec":
+            START_RE = new RegExp(`\/\/<${id}>`)
+            START_SPACE_RE = new RegExp(`\/\/ <${id}>`);;
+            END_RE = new RegExp(`\/\/<\/${id}>`)
+            END_SPACE_RE = new RegExp(`\/\/ <\/${id}>`);
             break;
           case "cs":
-            data.map((x, index) => {
-              const startMatch = new RegExp(`#region${id}`).exec(x);
-              if (startMatch) {
-                startLine = index;
-              }
-              const endMatch = new RegExp(`#endregion`).exec(x);
-              if (endMatch) {
-                endLine = index;
-                return;
-              }
-            });
+          case "csharp":
+            START_RE = new RegExp(`#region${id}`)
+            START_SPACE_RE = new RegExp(`#region ${id}`);
+            END_RE = new RegExp(`#endregion`);
+            END_SPACE_RE = new RegExp(`#endregion`);
             break;
-
+          case "xml":
+          case "html":
+            START_RE = new RegExp(`<!--<${id}>-->`)
+            START_SPACE_RE = new RegExp(`<!-- <${id}> -->`)
+            END_RE = new RegExp(`<!--<\/${id}>-->`)
+            END_SPACE_RE = new RegExp(`<!-- </${id}> -->`)
+            break;
+          case "sql":
+            START_RE = new RegExp(`--<${id}>`)
+            START_SPACE_RE = new RegExp(`-- <${id}>`);
+            END_RE = new RegExp(`-- <\/${id}>`)
+            END_SPACE_RE = new RegExp(`--<\/${id}>`);
+            break;
+          case "python":
+          case "powershell":
+          case "shell":
+          case "ruby":
+            START_RE = new RegExp(`#<${id}>`);
+            START_SPACE_RE = new RegExp(`# <${id}>`);
+            END_RE = new RegExp(`#<\/${id}>`);
+            END_SPACE_RE = new RegExp(`# <\/${id}>`);
+            break;
+          case "batchfile":
+            START_RE = new RegExp(`rem<${id}>`, "i");
+            START_SPACE_RE = new RegExp(`rem <${id}>`, "i");
+            END_RE = new RegExp(`rem<\/${id}>`, "i");
+            END_SPACE_RE = new RegExp(`rem <\/${id}>`, "i");
+            break;
+          case "erlang":
+            START_RE = new RegExp(`%<${id}>`);
+            START_SPACE_RE = new RegExp(`% <${id}>`);
+            END_RE = new RegExp(`%</${id}>`);
+            END_SPACE_RE = new RegExp(`% </${id}>`);
+            break;
+          case "lisp":
+            START_RE = new RegExp(`;<${id}>`);
+            START_SPACE_RE = new RegExp(`; <${id}>`);
+            END_RE = new RegExp(`;</${id}>`);
+            END_SPACE_RE = new RegExp(`; </${id}>`);
+            break;
           default:
+            // get all lines
+            startLine = 0;
+            endLine = data.length;
             break;
+        }
+        for (let index = 0; index < data.length; index++) {
+          if (START_RE.exec(data[index])) {
+            startLine = index;
+          } else if (START_SPACE_RE.exec(data[index])) {
+            startLine = index;
+          }
+          if (END_RE.exec(data[index])) {
+            endLine = index;
+            break;
+          } else if (END_SPACE_RE.exec(data[index])) {
+            endLine = index;
+            break;
+          }
+          if (index + 1 === data.length) {
+            endLine = data.length;
+            break;
+          }
         }
         data.map((x, index) => {
           if (index > startLine && index < endLine) {
@@ -188,13 +258,13 @@ export function tripleColonCodeSnippets(md, options) {
         rangeList.forEach((element) => {
           if (element.indexOf("-") > 0) {
             const rangeThru = element.split("-");
-            const startRange = parseInt(rangeThru[0]);
-            const endRange = parseInt(rangeThru.pop());
+            const startRange = parseInt(rangeThru[0], 10);
+            const endRange = parseInt(rangeThru.pop(), 10);
             for (let index = startRange; index <= endRange; index++) {
               rangeArr.push(index);
             }
           } else {
-            rangeArr.push(parseInt(element));
+            rangeArr.push(parseInt(element, 10));
           }
         });
         rangeArr.sort();
@@ -210,7 +280,9 @@ export function tripleColonCodeSnippets(md, options) {
         output = readFileSync(filePath, "utf8");
       }
       output = `\`\`\`${language}\r\n${output}\r\n\`\`\``;
-      src = src.slice(0, captureGroup.index) + output + src.slice(captureGroup.index + captureGroup[0].length, src.length);
+      src = src.slice(0, position) + output + src.slice(position + match.length, src.length);
+      // src = src.slice(0, captureGroup.index) + output + src.slice(captureGroup.index + captureGroup[0].length, src.length);
+      // }
     }
     return src;
   };

--- a/docs-preview/src/markdown-extensions/column.ts
+++ b/docs-preview/src/markdown-extensions/column.ts
@@ -77,12 +77,14 @@ export function column_end(md, options) {
     const removeCodeblockSpaces = (src: string) => {
         // let captureGroup;
         let matches = src.match(COLUMN_RE);
-        matches.map((element) => {
-            let position = src.indexOf(element);
-            let output = element.replace(CODEBLOCK_RE, "");
-            output = output.replace(COLUMN_END_RE, "\r\n:::column-end:::");
-            src = src.slice(0, position) + output + src.slice(position + element.length, src.length);
-        });
+        if (matches) {
+            matches.map((element) => {
+                let position = src.indexOf(element);
+                let output = element.replace(CODEBLOCK_RE, "");
+                output = output.replace(COLUMN_END_RE, "\r\n:::column-end:::");
+                src = src.slice(0, position) + output + src.slice(position + element.length, src.length);
+            });
+        }
         // while ((captureGroup = COLUMN_RE.exec(src))) {
         //   const output = captureGroup[0].replace(CODEBLOCK_RE, "");
         //   src = src.slice(0, captureGroup.index) + output + src.slice(captureGroup.index + captureGroup[0].length, src.length);

--- a/docs-preview/src/markdown-extensions/column.ts
+++ b/docs-preview/src/markdown-extensions/column.ts
@@ -3,11 +3,12 @@ import { output } from "../extension";
 export const columnOptions = {
     marker: ":",
     validate(params) {
-        return params.trim().match(/column(\s+span="([1-9]+)?")?:::/g) || params.trim().match(/column-end:::/g);
+        return params.trim().match(/column(\s+span="([1-9]+)?")?:::/g);
     },
     render(tokens, idx) {
         const RE = /column((\s+)span="([1-9]+)?")?:::/g;
         const start = RE.exec(tokens[idx].info.trim());
+        // const start = tokens[idx].info.trim().match(RE);
         if (start) {
             if (start[3]) {
                 return `<div class='column span${start[3]}'>`;
@@ -16,19 +17,76 @@ export const columnOptions = {
                 return "<div class='column'>";
             }
         } else {
-            // closing tag
-            return "</div>";
+            return "";
         }
     },
 };
 
-export function column_end(md, options) {
-    const CODEBLOCK_RE = /(:::column-end:::)/g;
-    const removeCodeblockSpaces = (src: string) => {
-        let captureGroup;
-        while ((captureGroup = CODEBLOCK_RE.exec(src))) {
-            src = src.slice(0, captureGroup.index) + "\r\n:::column-end:::" + src.slice(captureGroup.index + captureGroup[0].length, src.length);
+export const columnEndOptions = {
+    marker: ":",
+    validate(params) {
+        return params.trim().match(/column-end:::/g);
+    },
+    render(tokens, idx) {
+        const RE = /column-end:::/g;
+        const end = RE.exec(tokens[idx].info.trim());
+        if (end) {
+            // closing tag
+            return "</div>";
+        } else {
+            return "";
         }
+    },
+};
+
+
+// export function column_end(md, options) {
+//     const COLUMN_END_RE = /(:::column-end:::)/g;
+//     const COLUMN_END_WITH_TEXT_RE = /[ ]{5}[^]+?:::column-end:::/g;
+
+//     const removeCodeblockSpaces = (src: string) => {
+//         let captureGroup;
+//         let matches = src.match(COLUMN_END_WITH_TEXT_RE);
+//         matches.map((element) => {
+//             let position = src.indexOf(element);
+//             const output = element.replace(COLUMN_END_RE, "\r\n:::column-end:::");
+//             src = src.slice(0, position) + output + src.slice(position + element.length, src.length);
+//         });
+//         //     while ((captureGroup = COLUMN_END_RE.exec(src))) {
+
+//         //     src = src.slice(0, captureGroup.index) + "\r\n:::column-end:::" + src.slice(captureGroup.index + captureGroup[0].length, src.length);
+//         // }
+//         return src;
+//     };
+
+//     const customCodeBlock = (state) => {
+//         try {
+//             state.src = removeCodeblockSpaces(state.src);
+//         } catch (error) {
+//             output.appendLine(error);
+//         }
+//     };
+//     md.core.ruler.before("normalize", "custom_codeblock", customCodeBlock);
+// }
+
+
+export function column_end(md, options) {
+    const COLUMN_RE = /(?!:::column(\s+span="([1-9]+)?")?:::[\s\S])[ ]{5}[^]+?:::column-end:::/g
+    const CODEBLOCK_RE = /[ ]{5}/g
+    const COLUMN_END_RE = /(:::column-end:::)/g;
+    const removeCodeblockSpaces = (src: string) => {
+        // let captureGroup;
+        let matches = src.match(COLUMN_RE);
+        matches.map((element) => {
+            let position = src.indexOf(element);
+            let output = element.replace(CODEBLOCK_RE, "");
+            output = output.replace(COLUMN_END_RE, "\r\n:::column-end:::");
+            src = src.slice(0, position) + output + src.slice(position + element.length, src.length);
+        });
+        // while ((captureGroup = COLUMN_RE.exec(src))) {
+        //   const output = captureGroup[0].replace(CODEBLOCK_RE, "");
+        //   src = src.slice(0, captureGroup.index) + output + src.slice(captureGroup.index + captureGroup[0].length, src.length);
+        // }
         return src;
     };
 

--- a/docs-preview/src/markdown-extensions/row.ts
+++ b/docs-preview/src/markdown-extensions/row.ts
@@ -1,15 +1,30 @@
 export const rowOptions = {
     marker: ":",
     validate(params) {
-        return params.trim().match(/row:::/g) || params.trim().match(/row-end:::/g);
+        return params.trim().match(/row:::/g);
     },
     render(tokens, idx) {
         if (tokens[idx].info.trim().match(/row:::/g)) {
             // opening tag
             return "<div class='row'>";
         } else {
-            // closing tag
-            return "</div>";
+            return "";
         }
     },
 };
+
+export const rowEndOptions = {
+    marker: ":",
+    validate(params) {
+        return params.trim().match(/row-end:::/g);
+    },
+    render(tokens, idx) {
+        if (tokens[idx].info.trim().match(/row-end:::/g)) {
+            // closing tag
+            return "</div>";
+        } else {
+            return "";
+        }
+    },
+};
+


### PR DESCRIPTION
Added support for new triple colon code snippet extension. 
For example:
:::code language="cpp" source="../codesnippet/CPP/ca2240-implement-iserializable-correctly_2.cpp" range="3-8, 10-15" interactive="try-dotnet":::

- [x] docs-preview support for viewing code snippets from local source
- [x] docs-preview support for cross-repository reference
- [x] code snippet insertion support from docs-markdown
- [x] code snippet linting