### PR TITLE
Image linting alt-text required for unsupported attribute

### DIFF
--- a/docs-markdown/markdownlint-custom-rules/common.js
+++ b/docs-markdown/markdownlint-custom-rules/common.js
@@ -51,6 +51,7 @@ module.exports.imageOpen = /:::image/gmi;
 module.exports.imageSourceMatch = /source\s*=\s*"([a-zA-Z0-9\-_\.\,\;\:\\/\?\=\%\@s*]*)"/m;
 module.exports.imageAltTextMatch = /alt-text\s*=\s*"([a-zA-Z\-_\.\,\;\:\s*]*)"/m;
 module.exports.imageLocScopeMatch = /loc-scope\s*=\s*"([a-zA-Z\-_\.\,\;\:\s*]*)"/m;
+module.exports.imageAltTextTypes = ["content", "complex"];
 
 // Alert
 module.exports.alertOpener = /^>\s+\[!/gm; // regex to find "> [!"

--- a/docs-markdown/markdownlint-custom-rules/image.js
+++ b/docs-markdown/markdownlint-custom-rules/image.js
@@ -126,7 +126,7 @@ module.exports = {
                             }
                         }
 
-                        if (typeMatch[1] !== "icon") {
+                        if (common.imageAltTextTypes.indexOf(typeMatch[1]) !== -1) {
                             //do we have alt-text?
                             const altTextMatch = common.imageAltTextMatch.exec(content);
                             if (!altTextMatch || altTextMatch[1] === "") {


### PR DESCRIPTION
If image type is **content** or **complex**, check for required alt-text attribute.  Resolves issue with unsupported types returning alt-text required.