### PR TITLE
Filter for items in includes folders when inserting includes

### DIFF
--- a/docs-markdown/package-lock.json
+++ b/docs-markdown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-markdown",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2520,9 +2520,9 @@
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5947,6 +5947,22 @@
             "he": "1.1.1",
             "mkdirp": "0.5.1",
             "supports-color": "4.4.0"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.2",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
           }
         },
         "supports-color": {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -419,7 +419,9 @@
     "diff": "^4.0.1",
     "file-exists": "^5.0.1",
     "fs-exists-sync": "^0.1.0",
+    "glob": "^7.1.6",
     "graceful-fs": "^4.1.15",
+    "js-yaml": "^3.13.1",
     "lodash.merge": "^4.6.2",
     "markdownlint": "^0.11.0",
     "matcher": "^1.0.0",
@@ -427,8 +429,7 @@
     "recursive-readdir": "^2.2.2",
     "typescript-collections": "^1.2.3",
     "vscode-extension-telemetry": "^0.1.1",
-    "yamljs": "^0.3.0",
-    "js-yaml": "^3.13.1"
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "@types/graceful-fs": "^2.0.30",

--- a/docs-markdown/src/controllers/include-controller.ts
+++ b/docs-markdown/src/controllers/include-controller.ts
@@ -6,6 +6,8 @@ import { includeBuilder } from "../helper/utility";
 
 const telemetryCommand: string = "insertInclude";
 const markdownExtensionFilter = [".md"];
+const path = require("path");
+const os = require("os");
 
 export function insertIncludeCommand() {
     const commands = [
@@ -18,10 +20,9 @@ export function insertIncludeCommand() {
  * transforms the current selection into an include.
  */
 export function insertInclude() {
-    const path = require("path");
-    const dir = require("node-dir");
-    const os = require("os");
+    const glob = require("glob")
     const editor = vscode.window.activeTextEditor;
+
     if (!editor) {
         noActiveEditorMessage();
         return;
@@ -41,12 +42,7 @@ export function insertInclude() {
         return;
     }
 
-    // recursively get all the files from the root folder
-    dir.files(folderPath, (err: any, files: any) => {
-        if (err) {
-            throw err;
-        }
-
+    glob("**/includes/*.md", { cwd: folderPath, nocase: true, realpath: true }, function (er: any, files: any) {
         const items: vscode.QuickPickItem[] = [];
         files.sort();
 


### PR DESCRIPTION
Update include command to use glob for pattern matching.  Only markdown files in **includes** directories should be displayed in the quickpick menu.