### PR TITLE
Added new command/snippet. External link (opens in new tab).

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -94,11 +94,6 @@
         "category": "Docs"
       },
       {
-        "command": "insertExternalURL",
-        "title": "Link to external website (opens in new tab)",
-        "category": "Docs"
-      },
-      {
         "command": "applyImage",
         "title": "Image (Docs Markdown)",
         "category": "Docs"

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -109,6 +109,11 @@
         "category": "Docs"
       },
       {
+        "command": "insertImageWithGrayBorder",
+        "title": "Image with gray border",
+        "category": "Docs"
+      },
+      {
         "command": "applyIcon",
         "title": "Icon image",
         "category": "Docs"

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -94,6 +94,11 @@
         "category": "Docs"
       },
       {
+        "command": "insertExternalURL",
+        "title": "Link to external website (opens in new tab)",
+        "category": "Docs"
+      },
+      {
         "command": "applyImage",
         "title": "Image (Docs Markdown)",
         "category": "Docs"

--- a/docs-markdown/snippets/snippets.json
+++ b/docs-markdown/snippets/snippets.json
@@ -33,17 +33,5 @@
       ":::image type=\"complex\" source=\"\" alt-text=\"\":::\n\n:::image-end:::"
     ],
     "description": "Complex image"
-  },
-  "externalLink": {
-    "prefix": [
-      "link",
-      "ext"
-    ],
-    "body": [
-      "<a href=\"${1:url}\" target=\"_blank\" rel=\"noopener\">",
-      "    ${2:URL description} <span class=\"docon docon-navigate-external x-hidden-focus\"></span>",
-      "</a>"
-    ],
-    "description": "External link, opens in a new tab."
   }
 }

--- a/docs-markdown/snippets/snippets.json
+++ b/docs-markdown/snippets/snippets.json
@@ -33,5 +33,17 @@
       ":::image type=\"complex\" source=\"\" alt-text=\"\":::\n\n:::image-end:::"
     ],
     "description": "Complex image"
+  },
+  "externalLink": {
+    "prefix": [
+      "link",
+      "ext"
+    ],
+    "body": [
+      "<a href=\"${1:url}\" target=\"_blank\" rel=\"noopener\">",
+      "    ${2:URL description} <span class=\"docon docon-navigate-external x-hidden-focus\"></span>",
+      "</a>"
+    ],
+    "description": "External link, opens in a new tab."
   }
 }

--- a/docs-markdown/src/controllers/link-controller.ts
+++ b/docs-markdown/src/controllers/link-controller.ts
@@ -1,6 +1,6 @@
 import { commands, QuickPickItem, QuickPickOptions, window } from "vscode";
 import { checkExtension, sendTelemetryData } from "../helper/common";
-import { Insert, insertExternalURL, insertURL, MediaType, selectLinkType } from "./media-controller";
+import { Insert, insertURL, MediaType, selectLinkType } from "./media-controller";
 import { applyXref } from "./xref-controller";
 
 const telemetryCommand: string = "insertLink";
@@ -9,7 +9,6 @@ export function insertLinkCommand() {
     const commands = [
         { command: pickLinkType.name, callback: pickLinkType },
         { command: insertURL.name, callback: insertURL },
-        { command: insertExternalURL.name, callback: insertExternalURL },
     ];
     return commands;
 }
@@ -23,10 +22,6 @@ export function pickLinkType() {
     items.push({
         description: "",
         label: "$(globe) Link to web page",
-    });
-    items.push({
-        description: "",
-        label: "$(link-external) Link to external web page (opens in new tab)",
     });
     items.push({
         description: "",
@@ -56,9 +51,6 @@ export function pickLinkType() {
                 break;
             case "link to web page":
                 insertURL();
-                break;
-            case "link to external web page (opens in new tab)":
-                insertExternalURL();
                 break;
             case "link to heading":
                 selectLinkType();

--- a/docs-markdown/src/controllers/link-controller.ts
+++ b/docs-markdown/src/controllers/link-controller.ts
@@ -1,15 +1,15 @@
-import { QuickPickItem, QuickPickOptions, window, commands } from "vscode";
-import { sendTelemetryData, checkExtension } from "../helper/common";
-import { Insert, insertURL, selectLinkType } from "./media-controller";
+import { commands, QuickPickItem, QuickPickOptions, window } from "vscode";
+import { checkExtension, sendTelemetryData } from "../helper/common";
+import { Insert, insertExternalURL, insertURL, selectLinkType } from "./media-controller";
 import { applyXref } from "./xref-controller";
 
 const telemetryCommand: string = "insertLink";
-let commandOption: string;
 
 export function insertLinkCommand() {
     const commands = [
         { command: pickLinkType.name, callback: pickLinkType },
         { command: insertURL.name, callback: insertURL },
+        { command: insertExternalURL.name, callback: insertExternalURL },
     ];
     return commands;
 }
@@ -23,6 +23,10 @@ export function pickLinkType() {
     items.push({
         description: "",
         label: "$(globe) Link to web page",
+    });
+    items.push({
+        description: "",
+        label: "$(link-external) Link to external web page (opens in new tab)",
     });
     items.push({
         description: "",
@@ -44,30 +48,29 @@ export function pickLinkType() {
         if (!selection) {
             return;
         }
+
         const selectionWithoutIcon = selection.label.toLowerCase().split(")")[1].trim();
         switch (selectionWithoutIcon) {
             case "link to file in repo":
                 Insert(false);
-                commandOption = "link to file in repo";
                 break;
             case "link to web page":
                 insertURL();
-                commandOption = "link to web page";
+                break;
+            case "link to external web page (opens in new tab)":
+                insertExternalURL();
                 break;
             case "link to heading":
                 selectLinkType();
-                commandOption = "link to heading";
                 break;
             case "link to xref":
                 applyXref();
-                commandOption = "link to Xref";
                 break;
             case "generate a link report":
                 runLinkChecker();
-                commandOption = "generate a link report";
                 break;
         }
-        sendTelemetryData(telemetryCommand, commandOption);
+        sendTelemetryData(telemetryCommand, selectionWithoutIcon);
     });
 }
 

--- a/docs-markdown/src/controllers/link-controller.ts
+++ b/docs-markdown/src/controllers/link-controller.ts
@@ -1,6 +1,6 @@
 import { commands, QuickPickItem, QuickPickOptions, window } from "vscode";
 import { checkExtension, sendTelemetryData } from "../helper/common";
-import { Insert, insertExternalURL, insertURL, selectLinkType } from "./media-controller";
+import { Insert, insertExternalURL, insertURL, MediaType, selectLinkType } from "./media-controller";
 import { applyXref } from "./xref-controller";
 
 const telemetryCommand: string = "insertLink";
@@ -52,7 +52,7 @@ export function pickLinkType() {
         const selectionWithoutIcon = selection.label.toLowerCase().split(")")[1].trim();
         switch (selectionWithoutIcon) {
             case "link to file in repo":
-                Insert(false);
+                Insert(MediaType.Link);
                 break;
             case "link to web page":
                 insertURL();

--- a/docs-markdown/src/controllers/media-controller.ts
+++ b/docs-markdown/src/controllers/media-controller.ts
@@ -29,7 +29,6 @@ export function insertLinksAndMediaCommands() {
         { command: insertVideo.name, callback: insertVideo },
         { command: insertURL.name, callback: insertURL },
         { command: insertLink.name, callback: insertLink },
-        { command: insertExternalURL.name, callback: insertExternalURL },
         { command: insertImageWithGrayBorder.name, callback: insertImageWithGrayBorder },
         // { command: insertImage.name, callback: insertImage },
         { command: selectLinkType.name, callback: selectLinkType },
@@ -112,48 +111,6 @@ export function insertURL() {
             setCursorPosition(editor, selection.start.line, selection.start.character + contentToInsert.length);
         }
     });
-    sendTelemetryData(telemetryCommandLink, commandOption);
-}
-
-/**
- * Inserts an external URL
- */
-export async function insertExternalURL() {
-    commandOption = "externalNewTab";
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-        noActiveEditorMessage();
-        return;
-    }
-    const selection = editor.selection;
-    const selectedText = editor.document.getText(selection);
-
-    let options: vscode.InputBoxOptions = {
-        placeHolder: "Enter URL",
-        validateInput: (urlInput) => urlInput.startsWith("http://") || urlInput.startsWith("https://") ? "" :
-            "http:// or https:// is required for URLs. Link will not be added if prefix is not present.",
-    };
-
-    const url = await vscode.window.showInputBox(options);
-    // If the user adds a link that doesn't include the http(s) protocol, show a warning and don't add the link.
-    if (url === undefined) {
-        postWarning("Incorrect link syntax. Abandoning command.");
-    } else {
-        let contentToInsert;
-        if (selection.isEmpty) {
-            options = {
-                placeHolder: "Enter URL description (optional)",
-            };
-            const title = await vscode.window.showInputBox(options);
-            contentToInsert = externalLinkOpensInNewTabBuilder(url, title);
-            insertContentToEditor(editor, insertURL.name, contentToInsert);
-        } else {
-            contentToInsert = externalLinkOpensInNewTabBuilder(url, selectedText);
-            insertContentToEditor(editor, insertURL.name, contentToInsert, true);
-        }
-        setCursorPosition(editor, selection.start.line, selection.start.character + contentToInsert.length);
-    }
-
     sendTelemetryData(telemetryCommandLink, commandOption);
 }
 

--- a/docs-markdown/src/controllers/media-controller.ts
+++ b/docs-markdown/src/controllers/media-controller.ts
@@ -3,7 +3,7 @@
 import * as vscode from "vscode";
 import { insertBookmarkExternal, insertBookmarkInternal } from "../controllers/bookmark-controller";
 import { hasValidWorkSpaceRootPath, insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage, postWarning, sendTelemetryData, setCursorPosition } from "../helper/common";
-import { externalLinkBuilder, internalLinkBuilder, videoLinkBuilder } from "../helper/utility";
+import { externalLinkBuilder, externalLinkOpensInNewTabBuilder, internalLinkBuilder, videoLinkBuilder } from "../helper/utility";
 
 const telemetryCommandMedia: string = "insertMedia";
 const telemetryCommandLink: string = "insertLink";
@@ -14,6 +14,7 @@ export function insertLinksAndMediaCommands() {
         { command: insertVideo.name, callback: insertVideo },
         { command: insertURL.name, callback: insertURL },
         { command: insertLink.name, callback: insertLink },
+        { command: insertExternalURL.name, callback: insertExternalURL },
         // { command: insertImage.name, callback: insertImage },
         { command: selectLinkType.name, callback: selectLinkType },
         { command: selectLinkTypeToolbar.name, callback: selectLinkTypeToolbar },
@@ -89,6 +90,48 @@ export function insertURL() {
             setCursorPosition(editor, selection.start.line, selection.start.character + contentToInsert.length);
         }
     });
+    sendTelemetryData(telemetryCommandLink, commandOption);
+}
+
+/**
+ * Inserts an external URL
+ */
+export async function insertExternalURL() {
+    commandOption = "externalNewTab";
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        noActiveEditorMessage();
+        return;
+    }
+    const selection = editor.selection;
+    const selectedText = editor.document.getText(selection);
+
+    let options: vscode.InputBoxOptions = {
+        placeHolder: "Enter URL",
+        validateInput: (urlInput) => urlInput.startsWith("http://") || urlInput.startsWith("https://") ? "" :
+            "http:// or https:// is required for URLs. Link will not be added if prefix is not present.",
+    };
+
+    const url = await vscode.window.showInputBox(options);
+    // If the user adds a link that doesn't include the http(s) protocol, show a warning and don't add the link.
+    if (url === undefined) {
+        postWarning("Incorrect link syntax. Abandoning command.");
+    } else {
+        let contentToInsert;
+        if (selection.isEmpty) {
+            options = {
+                placeHolder: "Enter URL description (optional)",
+            };
+            const title = await vscode.window.showInputBox(options);
+            contentToInsert = externalLinkOpensInNewTabBuilder(url, title);
+            insertContentToEditor(editor, insertURL.name, contentToInsert);
+        } else {
+            contentToInsert = externalLinkOpensInNewTabBuilder(url, selectedText);
+            insertContentToEditor(editor, insertURL.name, contentToInsert, true);
+        }
+        setCursorPosition(editor, selection.start.line, selection.start.character + contentToInsert.length);
+    }
+
     sendTelemetryData(telemetryCommandLink, commandOption);
 }
 

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -282,6 +282,10 @@ export function internalLinkBuilder(isArt: boolean, pathSelection: any, selected
     return link;
 }
 
+export function externalLinkOpensInNewTabBuilder(link: string, title: string = "") {
+    return `<a href=\"${link}\" target=\"_blank\" rel=\"noopener\">\n    ${title || link} <span class=\"docon docon-navigate-external x-hidden-focus\"></span>\n</a>`;
+}
+
 export function externalLinkBuilder(link: string, title: string = "") {
     if (title === "") {
         title = link;

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -283,7 +283,7 @@ export function internalLinkBuilder(isArt: boolean, pathSelection: any, selected
 }
 
 export function externalLinkOpensInNewTabBuilder(link: string, title: string = "") {
-    return `<a href=\"${link}\" target=\"_blank\" rel=\"noopener\">\n    ${title || link} <span class=\"docon docon-navigate-external x-hidden-focus\"></span>\n</a>`;
+    return `<a href=\"${link}\" target=\"_blank\" rel=\"noopener\" title=\"${title || link} (opens in new tab)\">\n    ${title || link} <span class=\"docon docon-navigate-external x-hidden-focus\"></span>\n</a>`;
 }
 
 export function externalLinkBuilder(link: string, title: string = "") {

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -249,7 +249,7 @@ function getLanguage(language: string, ext: string | undefined) {
     return language
 }
 
-export function internalLinkBuilder(isArt: boolean, pathSelection: any, selectedText: string = "") {
+export function internalLinkBuilder(isArt: boolean, pathSelection: string, selectedText: string = "") {
     const os = require("os");
     let link = "";
 
@@ -282,8 +282,12 @@ export function internalLinkBuilder(isArt: boolean, pathSelection: any, selected
     return link;
 }
 
+export function imageWithGrayBorderBuilder(altText: string, imagePath: string) {
+    return `> [!div class="mx-imgBorder"]\n> ![${altText}](${imagePath})`;
+}
+
 export function externalLinkOpensInNewTabBuilder(link: string, title: string = "") {
-    return `<a href=\"${link}\" target=\"_blank\" rel=\"noopener\" title=\"${title || link} (opens in new tab)\">\n    ${title || link} <span class=\"docon docon-navigate-external x-hidden-focus\"></span>\n</a>`;
+    return `<a href="${link}" target="_blank" rel="noopener" title="${title || link} (opens in new tab)">\n    ${title || link} <span class="docon docon-navigate-external x-hidden-focus"></span>\n</a>`;
 }
 
 export function externalLinkBuilder(link: string, title: string = "") {

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -286,10 +286,6 @@ export function imageWithGrayBorderBuilder(altText: string, imagePath: string) {
     return `> [!div class="mx-imgBorder"]\n> ![${altText}](${imagePath})`;
 }
 
-export function externalLinkOpensInNewTabBuilder(link: string, title: string = "") {
-    return `<a href="${link}" target="_blank" rel="noopener" title="${title || link} (opens in new tab)">\n    ${title || link} <span class="docon docon-navigate-external x-hidden-focus"></span>\n</a>`;
-}
-
 export function externalLinkBuilder(link: string, title: string = "") {
     if (title === "") {
         title = link;


### PR DESCRIPTION
Hi @meganbradley,

Here is a much smaller pull request than my last. This one simply adds a new snippet and command for creating an external link which will open in a new tab. It's based on another PR that I have over in the guidance - [here](https://github.com/MicrosoftDocs/docs-help-pr/pull/2737). It is my belief that we should strive to keep our users on our site, to avoid context switching -- external links are perfect for opening in a new tab.

This is an example of what it renders like on our platform.

![image](https://user-images.githubusercontent.com/7679720/71733906-46c6a780-2e10-11ea-9b2f-66b8bbe877fe.png)

Please note that there are several key considerations with this pull request. It includes inline HTML, with an `a` and `span` element. These elements are [allow-listed here](https://review.docs.microsoft.com/en-us/help/onboard/admin/html-whitelist?branch=master) and I detailed this as part of this other related pull request [here](https://github.com/MicrosoftDocs/azure-docs-pr/pull/97243#issuecomment-567160782). As for the security concern, please note that I'm also using the `rel="noopener"` as [recommended here](https://developers.google.com/web/tools/lighthouse/audits/noopener#recommendations).

Screenshot of it in action:

![image](https://user-images.githubusercontent.com/7679720/71734536-cef97c80-2e11-11ea-92d9-de1ef9ef8040.png)

Here is the resulting content:

![image](https://user-images.githubusercontent.com/7679720/71734800-55ae5980-2e12-11ea-96d1-e6c58bc11c51.png)

