### PR TITLE
Bump docs-images version

### DIFF
--- a/docs-images/CHANGELOG.md
+++ b/docs-images/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.0.3 (January 3rd, 2020)
+
+- Update image links and readme.
+
 ## 0.0.2 (December 30th, 2019)
 
 - Added readme and change log.

--- a/docs-images/package.json
+++ b/docs-images/package.json
@@ -3,7 +3,7 @@
   "displayName": "docs-images",
   "description": "Docs Images Extension",
   "icon": "images/docs-logo-ms.png",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-images",
   "bugs": {


### PR DESCRIPTION
Hi @meganbradley and @IEvangelist , the publishing step failed earlier because the extension version was the same as the published version so this is just a quick PR to update the versioning for deployment.  Thanks