### PR TITLE
Fixed a bug where directories under include folders were not found

### DIFF
--- a/docs-markdown/package-lock.json
+++ b/docs-markdown/package-lock.json
@@ -496,6 +496,23 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "5.0.35",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
+      "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-2.0.30.tgz",
@@ -540,6 +557,12 @@
       "requires": {
         "@types/lodash": "*"
       }
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
     },
     "@types/node": {
       "version": "7.10.6",

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -439,6 +439,7 @@
     "@types/node-dir": "0.0.32",
     "@types/recursive-readdir": "^2.2.0",
     "@types/yamljs": "^0.2.30",
+    "@types/glob": "5.0.35",
     "jest": "^24.7.1",
     "jest-junit": "^6.3.0",
     "octicons": "^7.3.0",

--- a/docs-markdown/src/controllers/include-controller.ts
+++ b/docs-markdown/src/controllers/include-controller.ts
@@ -81,13 +81,15 @@ export async function insertInclude() {
 
         // strip markdown extension from label text.
         const includeText = qpSelection.label.replace(markdownExtension, "");
-        if (os.type() === "Windows_NT") {
-            result = includeBuilder((path.relative(activeFileDir, path.join
-                (qpSelection.description || "Unknown", qpSelection.label).split("\\").join("\\\\"))), includeText);
-        }
-        if (os.type() === "Darwin") {
-            result = includeBuilder((path.relative(activeFileDir, path.join
-                (qpSelection.description || "Unknown", qpSelection.label).split("//").join("//"))), includeText);
+        switch (os.type()) {
+            case "Windows_NT":
+                result = includeBuilder((path.relative(activeFileDir, path.join
+                    (qpSelection.description || "Unknown", qpSelection.label).split("\\").join("\\\\"))), includeText);
+                break;
+            case "Darwin":
+                result = includeBuilder((path.relative(activeFileDir, path.join
+                    (qpSelection.description || "Unknown", qpSelection.label).split("//").join("//"))), includeText);
+                break;
         }
 
         editor.edit((editBuilder) => {


### PR DESCRIPTION
Hi @meganbradley,

I was experiencing a bug where markdown files were not being displayed in the quick selection list when using the <kbd>F1</kbd> Docs: Include functionality. The issue is that the glob pattern didn't account for files potentially nested under an includes directory. For example, prior to this change the only markdown files displayed in the quick selection would be the `include-file.md` whereas, I was expected all the markdown files under the includes directory.

```
└── includes
     ├── subfolder
     │    ├── sub-file-01.md
     │    └── sub-file-02.md
     └── include-file.md
```

With this change, all of these markdown files are displayed.
