### PR TITLE
Added markdown context menu item to "Update ms.date Metadata Value"

### DIFF
--- a/docs-markdown/.vscode/settings.json
+++ b/docs-markdown/.vscode/settings.json
@@ -7,5 +7,21 @@
         "out": true // set this to false to include "out" folder in search results
     },
     "typescript.tsdk": "node_modules/typescript/lib",
-    "editor.formatOnSave": true // we want to use the TS server from our node_modules folder to control its version
+    "editor.formatOnSave": true,
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#3399ff",
+        "activityBar.activeBorder": "#bf0060",
+        "activityBar.foreground": "#15202b",
+        "activityBar.inactiveForeground": "#15202b99",
+        "activityBarBadge.background": "#bf0060",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "titleBar.activeBackground": "#007fff",
+        "titleBar.inactiveBackground": "#007fff99",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveForeground": "#e7e7e799",
+        "statusBar.background": "#007fff",
+        "statusBarItem.hoverBackground": "#3399ff",
+        "statusBar.foreground": "#e7e7e7"
+    },
+    "peacock.color": "#007fff" // we want to use the TS server from our node_modules folder to control its version
 }

--- a/docs-markdown/.vscode/settings.json
+++ b/docs-markdown/.vscode/settings.json
@@ -7,21 +7,5 @@
         "out": true // set this to false to include "out" folder in search results
     },
     "typescript.tsdk": "node_modules/typescript/lib",
-    "editor.formatOnSave": true,
-    "workbench.colorCustomizations": {
-        "activityBar.background": "#3399ff",
-        "activityBar.activeBorder": "#bf0060",
-        "activityBar.foreground": "#15202b",
-        "activityBar.inactiveForeground": "#15202b99",
-        "activityBarBadge.background": "#bf0060",
-        "activityBarBadge.foreground": "#e7e7e7",
-        "titleBar.activeBackground": "#007fff",
-        "titleBar.inactiveBackground": "#007fff99",
-        "titleBar.activeForeground": "#e7e7e7",
-        "titleBar.inactiveForeground": "#e7e7e799",
-        "statusBar.background": "#007fff",
-        "statusBarItem.hoverBackground": "#3399ff",
-        "statusBar.foreground": "#e7e7e7"
-    },
-    "peacock.color": "#007fff" // we want to use the TS server from our node_modules folder to control its version
+    "editor.formatOnSave": true // we want to use the TS server from our node_modules folder to control its version
 }

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -172,6 +172,11 @@
         "command": "insertRowsAndColumns",
         "title": "Columns",
         "category": "Docs"
+      },
+      {
+        "command": "updateMetadataDate",
+        "title": "Update \"ms.date\" Metadata Value",
+        "category": "Docs"
       }
     ],
     "menus": {
@@ -181,6 +186,13 @@
           "command": "markdown.showPreview",
           "alt": "markdown.showPreviewToSide",
           "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "when": "resourceLangId == markdown",
+          "command": "updateMetadataDate",
+          "group": "1_modification"
         }
       ],
       "commandPalette": [

--- a/docs-markdown/src/controllers/metadata-controller.ts
+++ b/docs-markdown/src/controllers/metadata-controller.ts
@@ -25,18 +25,18 @@ export async function updateMetadataDate() {
     const content = editor.document.getText();
     if (content) {
         const result = msDateRegex.exec(content);
-        if (result !== null) {
+        if (result !== null && result.length) {
             const match = result[0];
             if (match) {
                 const index = result.index;
-                const today = new Date();
                 const wasEdited = await editor.edit((builder) => {
                     const startPosition = editor.document.positionAt(index);
                     const endPosition = editor.document.positionAt(index + match.length);
                     const selection = new Selection(startPosition, endPosition);
+
                     builder.replace(
                         selection,
-                        `ms.date: ${toShortDate(today)}`);
+                        `ms.date: ${toShortDate(new Date())}`);
                 });
 
                 if (wasEdited) {

--- a/docs-markdown/src/controllers/metadata-controller.ts
+++ b/docs-markdown/src/controllers/metadata-controller.ts
@@ -1,0 +1,57 @@
+"use strict";
+
+import { Selection, window } from "vscode";
+import { isMarkdownFileCheck, noActiveEditorMessage, sendTelemetryData } from "../helper/common";
+
+export function insertMetadataCommands() {
+    return [
+        { command: updateMetadataDate.name, callback: updateMetadataDate },
+    ];
+}
+
+const msDateRegex = /ms.date:\s*\b(.+?)$/mi;
+
+export function updateMetadataDate() {
+    const editor = window.activeTextEditor;
+    if (!editor) {
+        noActiveEditorMessage();
+        return;
+    }
+
+    if (!isMarkdownFileCheck(editor, false)) {
+        return;
+    }
+
+    const content = editor.document.getText();
+    if (content) {
+        const result = msDateRegex.exec(content);
+        if (result !== null) {
+            const match = result[0];
+            if (match) {
+                const index = result.index;
+                const today = new Date();
+                editor.edit((builder) => {
+                    const startPosition = editor.document.positionAt(index);
+                    const endPosition = editor.document.positionAt(index + match.length);
+                    const selection = new Selection(startPosition, endPosition);
+                    builder.replace(
+                        selection,
+                        `ms.date: ${toShortDate(today)}`);
+                });
+
+                const telemetryCommand = "updateMetadata";
+                sendTelemetryData(telemetryCommand, updateMetadataDate.name);
+            }
+        }
+    }
+}
+
+function toShortDate(date: Date) {
+    const year = date.getFullYear();
+    const month = (1 + date.getMonth()).toString();
+    const monthStr = month.length > 1 ? month : `0${month}`;
+    const day = date.getDate().toString();
+    const dayStr = day.length > 1 ? day : `0${day}`;
+
+    return `${monthStr}/${dayStr}/${year}`;
+}

--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -19,6 +19,7 @@ import { addFrontMatterTitle } from "./controllers/lint-config-controller";
 import { insertListsCommands } from "./controllers/list-controller";
 import { getMasterRedirectionCommand } from "./controllers/master-redirect-controller";
 import { insertLinksAndMediaCommands } from "./controllers/media-controller";
+import { insertMetadataCommands } from "./controllers/metadata-controller";
 import { noLocCompletionItemsMarkdown, noLocCompletionItemsMarkdownYamlHeader, noLocCompletionItemsYaml, noLocTextCommand } from "./controllers/no-loc-controller";
 import { previewTopicCommand } from "./controllers/preview-controller";
 import { quickPickMenuCommand } from "./controllers/quick-pick-menu-controller";
@@ -81,6 +82,7 @@ export function activate(context: ExtensionContext) {
     noLocTextCommand().forEach((cmd) => AuthoringCommands.push(cmd));
     insertRowsAndColumnsCommand().forEach((cmd) => AuthoringCommands.push(cmd));
     insertImageCommand().forEach((cmd) => AuthoringCommands.push(cmd));
+    insertMetadataCommands().forEach((cmd) => AuthoringCommands.push(cmd));
 
     // Autocomplete
     context.subscriptions.push(setupAutoComplete());

--- a/docs-markdown/src/helper/common.ts
+++ b/docs-markdown/src/helper/common.ts
@@ -133,7 +133,7 @@ export function hasValidWorkSpaceRootPath(senderName: string) {
  * If overwrite is set the content will replace current selection.
  * @param {vscode.TextEditor} editor - the active editor in vs code.
  * @param {string} senderName - the name of the function that is calling this function
- * which is used to provide tracibility in logging.
+ * which is used to provide traceability in logging.
  * @param {string} string - the content to insert.
  * @param {boolean} overwrite - if true replaces current selection.
  * @param {vscode.Range} selection - if null uses the current selection for the insert or update.

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -99,10 +99,10 @@ export async function search(editor: vscode.TextEditor, selection: vscode.Select
     const path = require("path");
     let language: string = "";
     let selected: vscode.QuickPickItem | undefined;
-    let activeFilePath
+    let activeFilePath;
     let snippetLink: string = "";
     if (!crossReference) {
-        let searchTerm = await vscode.window.showInputBox({ prompt: "Enter snippet search terms." })
+        const searchTerm = await vscode.window.showInputBox({ prompt: "Enter snippet search terms." });
         if (!searchTerm) {
             return;
         }
@@ -153,13 +153,13 @@ export async function search(editor: vscode.TextEditor, selection: vscode.Select
 
     vscode.window.showQuickPick(selectorOptions).then((selectorChoice) => {
         if (selectorChoice) {
-            let id: string;
-            let range: string;
+            let snippet: string;
+
             switch (selectorChoice.label.toLowerCase()) {
                 case "id":
                     vscode.window.showInputBox({ prompt: "Enter id to select" }).then((id) => {
                         if (id) {
-                            const snippet: string = snippetBuilder(language, snippetLink, id, range);
+                            snippet = snippetBuilder(language, snippetLink, id, undefined);
                             common.insertContentToEditor(editor, search.name, snippet, true, selectionRange);
                         }
                     });
@@ -167,13 +167,13 @@ export async function search(editor: vscode.TextEditor, selection: vscode.Select
                 case "range":
                     vscode.window.showInputBox({ prompt: "Enter line selection range" }).then((range) => {
                         if (range) {
-                            const snippet: string = snippetBuilder(language, snippetLink, id, range);
+                            snippet = snippetBuilder(language, snippetLink, undefined, range);
                             common.insertContentToEditor(editor, search.name, snippet, true, selectionRange);
                         }
                     });
                     break;
                 default:
-                    const snippet: string = snippetBuilder(language, snippetLink);
+                    snippet = snippetBuilder(language, snippetLink);
                     common.insertContentToEditor(editor, search.name, snippet, true, selectionRange);
                     break;
             }
@@ -223,8 +223,8 @@ function getLanguage(language: string, ext: string | undefined) {
         { typescript: ["ts", ".ts"] },
         { xaml: [".xaml"] },
         { xml: ["xsl", "xslt", "xsd", "wsdl", ".xml", ".csdl", ".edmx", ".xsl", ".xslt", ".xsd", ".wsdl"] },
-        { vb: ["vbnet", "vbscript", ".vb", ".bas", ".vbs", ".vba"] }
-    ]
+        { vb: ["vbnet", "vbscript", ".vb", ".bas", ".vbs", ".vba"] },
+    ];
 
     for (const key in dict) {
         if (dict.hasOwnProperty(key)) {
@@ -246,7 +246,7 @@ function getLanguage(language: string, ext: string | undefined) {
         return ext.substr(1);
     }
 
-    return language
+    return language;
 }
 
 export function internalLinkBuilder(isArt: boolean, pathSelection: any, selectedText: string = "") {


### PR DESCRIPTION
Hi @meganbradley,

I added the ability to right-click within a markdown file and update the `ms.date` value to the current date. This will save me and hopefully many others a lot of time in the future. Here is an example of it in action:

Notice the date value now. Right-click in markdown file, select "Update "ms.date" Metadata Value" option

![image](https://user-images.githubusercontent.com/7679720/72401847-e3dbe700-3712-11ea-9ce0-18c0c36bfe1f.png)

Now observe the updated date.

![image](https://user-images.githubusercontent.com/7679720/72401884-fce49800-3712-11ea-8237-85d6aa54e8d7.png)

I also cleaned up a few minor things that observed while exploring the code.
