### PR TITLE
Added the ability to insert links from yaml files.

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -256,7 +256,7 @@
         {
           "command": "insertLink",
           "group": "Docs",
-          "when": "resourceLangId == markdown"
+          "when": "resourceLangId == markdown || resourceLangId == yaml"
         },
         {
           "command": "insertURL",

--- a/docs-markdown/src/controllers/link-controller.ts
+++ b/docs-markdown/src/controllers/link-controller.ts
@@ -1,18 +1,18 @@
-import { QuickPickItem, QuickPickOptions, window, commands } from "vscode";
-import { sendTelemetryData, checkExtension } from "../helper/common";
-import { Insert, insertURL, selectLinkType } from "./media-controller";
+import { commands, QuickPickItem, QuickPickOptions, window } from "vscode";
+import { checkExtension, sendTelemetryData } from "../helper/common";
+import { Insert, insertURL, MediaType, selectLinkType } from "./media-controller";
 import { applyXref } from "./xref-controller";
 
 const telemetryCommand: string = "insertLink";
 let commandOption: string;
 
 export function insertLinkCommand() {
-    const commands = [
+    return [
         { command: pickLinkType.name, callback: pickLinkType },
         { command: insertURL.name, callback: insertURL },
     ];
-    return commands;
 }
+
 export function pickLinkType() {
     const opts: QuickPickOptions = { placeHolder: "Select an Link type" };
     const items: QuickPickItem[] = [];
@@ -47,7 +47,7 @@ export function pickLinkType() {
         const selectionWithoutIcon = selection.label.toLowerCase().split(")")[1].trim();
         switch (selectionWithoutIcon) {
             case "link to file in repo":
-                Insert(false);
+                Insert(MediaType.Link);
                 commandOption = "link to file in repo";
                 break;
             case "link to web page":

--- a/docs-markdown/src/controllers/media-controller.ts
+++ b/docs-markdown/src/controllers/media-controller.ts
@@ -198,7 +198,7 @@ export function getFilesShowQuickPick(mediaType: MediaType, altText: string, opt
                     }
                 }
 
-                const languageId = options?.languageId || undefined;
+                const languageId = options ? options.languageId : undefined;
                 // Construct and write out links
                 if (isArt && altText) {
                     if (altText.length > 250) {
@@ -297,7 +297,8 @@ export function Insert(mediaType: MediaType, options?: IOptions) {
         }
 
         // Determine if there is selected text.  If selected text, no action.
-        if (selectedText === "" && options?.languageId !== "yaml") {
+        const languageId = !!options ? options.languageId : undefined;
+        if (selectedText === "" && languageId !== "yaml") {
             vscode.window.showInputBox({
                 placeHolder: "Add alt text (up to 250 characters)",
             }).then((val) => {

--- a/docs-markdown/src/controllers/media-controller.ts
+++ b/docs-markdown/src/controllers/media-controller.ts
@@ -2,7 +2,7 @@
 
 import * as vscode from "vscode";
 import { insertBookmarkExternal, insertBookmarkInternal } from "../controllers/bookmark-controller";
-import { hasValidWorkSpaceRootPath, insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage, postWarning, sendTelemetryData, setCursorPosition } from "../helper/common";
+import { hasValidWorkSpaceRootPath, insertContentToEditor, isMarkdownFileCheck, isValidEditor, isValidFileCheck, noActiveEditorMessage, postWarning, sendTelemetryData, setCursorPosition, unsupportedFileMessage } from "../helper/common";
 import { externalLinkBuilder, internalLinkBuilder, videoLinkBuilder } from "../helper/utility";
 
 const telemetryCommandMedia: string = "insertMedia";
@@ -22,12 +22,22 @@ export function insertLinksAndMediaCommands() {
     return commands;
 }
 
+interface IOptions {
+    languageId: string;
+}
+
 const imageExtensions = [".jpeg", ".jpg", ".png", ".gif", ".bmp"];
 const markdownExtensionFilter = [".md"];
 
 export const h1TextRegex = /\n {0,3}(#{1,6})(.*)/;
 export const headingTextRegex = /^(#+)[\s](.*)[\r]?[\n]/gm;
 export const yamlTextRegex = /^-{3}\s*\r?\n([\s\S]*?)-{3}\s*\r?\n([\s\S]*)/;
+
+export enum MediaType {
+    Link,
+    ImageOrVideo,
+    GrayBorderImage,
+}
 
 export function insertVideo() {
     commandOption = "video";
@@ -96,17 +106,32 @@ export function insertURL() {
  * Inserts a link
  */
 export function insertLink() {
-    Insert(false);
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        noActiveEditorMessage();
+        return;
+    }
+
+    const languageId = editor.document.languageId;
+    const isMarkdown = languageId === "markdown";
+    const isYaml = languageId === "yaml";
+
+    if (!isMarkdown && !isYaml) {
+        unsupportedFileMessage(languageId);
+        return;
+    }
+
+    Insert(MediaType.Link, { languageId });
 }
 
 /**
  * Triggers the insert function and passes in the true value to signify it is an art insert.
  */
 export function insertImage() {
-    Insert(true);
+    Insert(MediaType.ImageOrVideo);
 }
 
-export function getFilesShowQuickPick(isArt: any, altText: string) {
+export function getFilesShowQuickPick(mediaType: MediaType, altText: string, options?: IOptions) {
     const path = require("path");
     const dir = require("node-dir");
     const os = require("os");
@@ -136,11 +161,10 @@ export function getFilesShowQuickPick(isArt: any, altText: string) {
         const items: vscode.QuickPickItem[] = [];
         files.sort();
 
+        const isArt = mediaType !== MediaType.Link;
         if (isArt) {
-
             files.filter((file: any) => imageExtensions.indexOf(path.extname(file.toLowerCase())) !== -1).forEach((file: any) => {
                 items.push({ label: path.basename(file), description: path.dirname(file) });
-
             });
         } else {
             files.filter((file: any) => markdownExtensionFilter.indexOf(path.extname(file.toLowerCase()))
@@ -155,7 +179,7 @@ export function getFilesShowQuickPick(isArt: any, altText: string) {
             if (!qpSelection) {
                 return;
             } else {
-                let result: any;
+                let result: string = "";
                 const altTextFileName = qpSelection.label;
                 // Gets the H1 content as default name if unselected text. Will filter undefinition H1, non-MD file.
                 if (!isArt && selectedText === "") {
@@ -174,37 +198,40 @@ export function getFilesShowQuickPick(isArt: any, altText: string) {
                     }
                 }
 
+                const languageId = options?.languageId || undefined;
                 // Construct and write out links
                 if (isArt && altText) {
                     if (altText.length > 250) {
                         vscode.window.showWarningMessage("Alt text exceeds 250 characters!");
                     } else {
                         result = internalLinkBuilder(isArt, path.relative(activeFileDir, path.join
-                            (qpSelection.description, qpSelection.label).split("\\").join("\\\\")), altText);
+                            (qpSelection.description, qpSelection.label).split("\\").join("\\\\")), altText, languageId);
                     }
 
                 } else if (isArt && altText === "") {
                     result = internalLinkBuilder(isArt, path.relative(activeFileDir, path.join
-                        (qpSelection.description, qpSelection.label).split("\\").join("\\\\")), altTextFileName);
+                        (qpSelection.description, qpSelection.label).split("\\").join("\\\\")), altTextFileName, languageId);
                 } else if (!isArt) {
                     result = internalLinkBuilder(isArt, path.relative(activeFileDir, path.join
-                        (qpSelection.description, qpSelection.label).split("\\").join("\\\\")), selectedText);
+                        (qpSelection.description, qpSelection.label).split("\\").join("\\\\")), selectedText, languageId);
                 }
 
                 if (os.type() === "Darwin") {
                     if (isArt) {
                         result = internalLinkBuilder(isArt, path.relative(activeFileDir, path.join
-                            (qpSelection.description, qpSelection.label).split("//").join("//")), altText);
+                            (qpSelection.description, qpSelection.label).split("//").join("//")), altText, languageId);
                     } else {
                         result = internalLinkBuilder(isArt, path.relative(activeFileDir, path.join
-                            (qpSelection.description, qpSelection.label).split("//").join("//")), selectedText);
+                            (qpSelection.description, qpSelection.label).split("//").join("//")), selectedText, languageId);
                     }
                 }
 
-                // Insert content into topic
-                insertContentToEditor(editor, Insert.name, result, true);
-                if (!isArt) {
-                    setCursorPosition(editor, selection.start.line, selection.start.character + result.length);
+                if (!!result) {
+                    // Insert content into topic
+                    insertContentToEditor(editor, Insert.name, result, true);
+                    if (!isArt) {
+                        setCursorPosition(editor, selection.start.line, selection.start.character + result.length);
+                    }
                 }
             }
         });
@@ -212,10 +239,11 @@ export function getFilesShowQuickPick(isArt: any, altText: string) {
 }
 
 /**
- * Inserts a link or art.
- * @param {boolean} isArt - if true inserts art, if false inserts link.
+ * Inserts various media types.
+ * @param {MediaType} mediaType - the media type to insert.
+ * @param {IOptions} [options] - optionally specifies the language identifier of the target file.
  */
-export function Insert(isArt: any) {
+export function Insert(mediaType: MediaType, options?: IOptions) {
 
     let actionType: string = Insert.name;
 
@@ -226,23 +254,27 @@ export function Insert(isArt: any) {
     } else {
         const selectedText = editor.document.getText(editor.selection);
 
-        // determines the name to set in the ValidEditor check
-        if (isArt) {
-            actionType = "Art";
-            commandOption = "art";
-            sendTelemetryData(telemetryCommandMedia, commandOption);
-        } else {
-            actionType = "Link";
-            commandOption = "internal";
-            sendTelemetryData(telemetryCommandLink, commandOption);
+        // Determines the name to set in the ValidEditor check
+        switch (mediaType) {
+            case MediaType.ImageOrVideo:
+                actionType = "Art";
+                commandOption = "art";
+                sendTelemetryData(telemetryCommandMedia, commandOption);
+                break;
+            case MediaType.Link:
+                actionType = "Link";
+                commandOption = "internal";
+                sendTelemetryData(telemetryCommandLink, commandOption);
+                break;
         }
 
-        // checks for valid environment
+        // Checks for valid environment
         if (!isValidEditor(editor, false, actionType)) {
             return;
         }
 
-        if (!isMarkdownFileCheck(editor, false)) {
+        // We have some cross-over functionality in both YAML and Markdown
+        if (!isValidFileCheck(editor, ["markdown", "yaml"])) {
             return;
         }
 
@@ -259,29 +291,27 @@ export function Insert(isArt: any) {
         // Check to see if the active file has been saved.  If it has not been saved, warn the user.
         // The user will still be allowed to add a link but it the relative path will not be resolved.
         const fileExists = require("file-exists");
-
         if (!fileExists(activeFileName)) {
-            vscode.window.showWarningMessage(activeFilePath +
-                " is not saved.  Cannot accurately resolve path to create link.");
+            vscode.window.showWarningMessage(`${activeFilePath} is not saved. Cannot accurately resolve path to create link.`);
             return;
         }
 
         // Determine if there is selected text.  If selected text, no action.
-        if (isArt && selectedText === "") {
+        if (selectedText === "" && options?.languageId !== "yaml") {
             vscode.window.showInputBox({
                 placeHolder: "Add alt text (up to 250 characters)",
             }).then((val) => {
                 if (!val) {
-                    getFilesShowQuickPick(isArt, "");
+                    getFilesShowQuickPick(mediaType, "", options);
                     vscode.window.showInformationMessage("No alt entered or selected.  File name will be used.");
                 } else if (val.length < 250) {
-                    getFilesShowQuickPick(isArt, val);
+                    getFilesShowQuickPick(mediaType, val, options);
                 } else if (val.length > 250) {
                     vscode.window.showWarningMessage("Alt text exceeds 250 characters!");
                 }
             });
         } else {
-            getFilesShowQuickPick(isArt, selectedText);
+            getFilesShowQuickPick(mediaType, selectedText, options);
         }
     }
 }
@@ -337,7 +367,7 @@ export function selectLinkTypeToolbar(toolbar?: boolean) {
         if (qpSelection === linkTypes[0]) {
             insertURL();
         } else if (qpSelection === linkTypes[1]) {
-            Insert(false);
+            Insert(MediaType.Link);
         } else if (qpSelection === linkTypes[2]) {
             insertBookmarkInternal();
         } else if (qpSelection === linkTypes[3]) {
@@ -366,7 +396,7 @@ export function selectMediaType() {
         const mediaTypes = ["Image", "Video"];
         vscode.window.showQuickPick(mediaTypes).then((qpSelection) => {
             if (qpSelection === mediaTypes[0]) {
-                Insert(true);
+                Insert(MediaType.ImageOrVideo);
             } else if (qpSelection === mediaTypes[1]) {
                 insertVideo();
             }

--- a/docs-markdown/src/controllers/quick-pick-menu-controller.ts
+++ b/docs-markdown/src/controllers/quick-pick-menu-controller.ts
@@ -11,7 +11,7 @@ import { pickImageType } from "./image-controller";
 import { insertInclude } from "./include-controller";
 import { formatItalic } from "./italic-controller";
 import { insertBulletedList, insertNumberedList } from "./list-controller";
-import { insertVideo } from "./media-controller";
+import { insertVideo, insertLink } from "./media-controller";
 import { noLocText } from "./no-loc-controller";
 import { previewTopic } from "./preview-controller";
 import { insertRowsAndColumns } from "./row-columns-controller";
@@ -128,6 +128,10 @@ export function markdownQuickPick() {
         },
         {
             description: "",
+            label: "$(link) Insert link",
+        },
+        {
+            description: "",
             label: "$(lock) Non-localizable text",
         },
     );
@@ -217,6 +221,9 @@ export function markdownQuickPick() {
                 break;
             case "parent node":
                 insertExpandableParentNode();
+                break;
+            case "insert link":
+                insertLink();
                 break;
             case "columns":
                 insertRowsAndColumns();

--- a/docs-markdown/src/helper/common.ts
+++ b/docs-markdown/src/helper/common.ts
@@ -75,6 +75,10 @@ export function noActiveEditorMessage() {
     postWarning("No active editor. Abandoning command.");
 }
 
+export function unsupportedFileMessage(languageId: string) {
+    postWarning(`Command is not support for "${languageId}". Abandoning command.`);
+}
+
 export function GetEditorText(editor: vscode.TextEditor, senderName: string): string {
     let content = "";
     const emptyString = "";
@@ -265,6 +269,10 @@ export function isMarkdownFileCheck(editor: vscode.TextEditor, languageId: boole
     } else {
         return true;
     }
+}
+
+export function isValidFileCheck(editor: vscode.TextEditor, languageIds: string[]) {
+    return languageIds.some((id) => editor.document.languageId === id);
 }
 
 /**

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -249,10 +249,9 @@ function getLanguage(language: string, ext: string | undefined) {
     return language;
 }
 
-export function internalLinkBuilder(isArt: boolean, pathSelection: any, selectedText: string = "") {
+export function internalLinkBuilder(isArt: boolean, pathSelection: string, selectedText: string = "", languageId?: string) {
     const os = require("os");
     let link = "";
-
     let startBrace = "";
     if (isArt) {
         startBrace = "![";
@@ -262,9 +261,15 @@ export function internalLinkBuilder(isArt: boolean, pathSelection: any, selected
 
     // replace the selected text with the properly formatted link
     if (pathSelection === "") {
-        link = startBrace + selectedText + "]()";
+        link = `${startBrace}${selectedText}]()`;
     } else {
-        link = startBrace + selectedText + "](" + pathSelection + ")";
+        link = `${startBrace}${selectedText}](${pathSelection})`;
+    }
+
+    const langId = languageId || "markdown";
+    const isYaml = langId === "yaml" && !isArt;
+    if (isYaml) {
+        link = pathSelection;
     }
 
     // The relative path comparison creates an additional level that is not needed and breaks linking.


### PR DESCRIPTION
Hi @meganbradley,

I have added the ability to insert links from yaml files. This is HUGELY helpful with links that we create in `index.yml` and `toc.yml` files. Today we do not have support in place for this functionality. Here is an example of it working...

![yaml-links](https://user-images.githubusercontent.com/7679720/72906593-1760d780-3cf8-11ea-98d0-d0b10240f8ac.gif)

