### PR TITLE
Added the ability to sort selections: asc or desc.

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.2.34",
+  "version": "0.2.36",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {
@@ -177,6 +177,18 @@
         "command": "updateMetadataDate",
         "title": "Update \"ms.date\" Metadata Value",
         "category": "Docs"
+      },
+      {
+        "command": "sortSelectionAscending",
+        "title": "Sort selection ascending (A to Z)",
+        "category": "Docs",
+        "enablement": "resourceLangId == markdown"
+      },
+      {
+        "command": "sortSelectionDescending",
+        "title": "Sort selection descending (Z to A)",
+        "category": "Docs",
+        "enablement": "resourceLangId == markdown"
       }
     ],
     "menus": {
@@ -192,6 +204,16 @@
         {
           "when": "resourceLangId == markdown",
           "command": "updateMetadataDate",
+          "group": "1_modification"
+        },
+        {
+          "when": "editorHasSelection",
+          "command": "sortSelectionAscending",
+          "group": "1_modification"
+        },
+        {
+          "when": "editorHasSelection",
+          "command": "sortSelectionDescending",
           "group": "1_modification"
         }
       ],

--- a/docs-markdown/src/controllers/sort-controller.ts
+++ b/docs-markdown/src/controllers/sort-controller.ts
@@ -37,7 +37,11 @@ function sortLines(ascending: boolean = true) {
         lines.push(editor.document.lineAt(i).text);
     }
 
-    lines.sort();
+    const naturalLanguageCompare = (a: string, b: string) => {
+        return (!!a && !!b) ? a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }) : 0;
+    };
+
+    lines.sort(naturalLanguageCompare);
     if (!ascending) {
         lines.reverse();
     }

--- a/docs-markdown/src/controllers/sort-controller.ts
+++ b/docs-markdown/src/controllers/sort-controller.ts
@@ -1,0 +1,51 @@
+import { Range, window } from "vscode";
+import { noActiveEditorMessage, sendTelemetryData } from "../helper/common";
+
+const telemetryCommandLink: string = "sortSelection";
+
+export function insertSortSelectionCommands() {
+    return [
+        { command: sortSelectionAscending.name, callback: sortSelectionAscending },
+        { command: sortSelectionDescending.name, callback: sortSelectionDescending },
+    ];
+}
+
+export function sortSelectionAscending(): Thenable<boolean> | undefined {
+    return sortLines(true);
+}
+
+export function sortSelectionDescending(): Thenable<boolean> | undefined {
+    return sortLines(false);
+}
+
+function sortLines(ascending: boolean = true) {
+    const editor = window.activeTextEditor;
+    if (!editor) {
+        noActiveEditorMessage();
+        return undefined;
+    }
+
+    const selection = editor.selection;
+    if (selection.isEmpty || selection.isSingleLine) {
+        return undefined;
+    }
+
+    const startLine = selection.start.line;
+    const endLine = selection.end.line;
+    const lines: string[] = [];
+    for (let i = startLine; i <= endLine; ++i) {
+        lines.push(editor.document.lineAt(i).text);
+    }
+
+    lines.sort();
+    if (!ascending) {
+        lines.reverse();
+    }
+
+    sendTelemetryData(telemetryCommandLink, ascending ? "sortAscending" : "sortDescending");
+
+    return editor.edit((builder) => {
+        const range = new Range(startLine, 0, endLine, editor.document.lineAt(endLine).text.length);
+        builder.replace(range, lines.join("\n"));
+    });
+}

--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -32,6 +32,7 @@ import { checkExtension, extractDocumentLink, generateTimestamp, matchAll, noAct
 import { Reporter } from "./helper/telemetry";
 import { UiHelper } from "./helper/ui";
 import { isCursorInsideYamlHeader } from "./helper/yaml-metadata";
+import { insertSortSelectionCommands } from "./controllers/sort-controller";
 
 export const output = window.createOutputChannel("docs-markdown");
 export let extensionPath: string;
@@ -83,6 +84,7 @@ export function activate(context: ExtensionContext) {
     insertRowsAndColumnsCommand().forEach((cmd) => AuthoringCommands.push(cmd));
     insertImageCommand().forEach((cmd) => AuthoringCommands.push(cmd));
     insertMetadataCommands().forEach((cmd) => AuthoringCommands.push(cmd));
+    insertSortSelectionCommands().forEach((cmd) => AuthoringCommands.push(cmd));
 
     // Autocomplete
     context.subscriptions.push(setupAutoComplete());


### PR DESCRIPTION
Hi @meganbradley,

I added the ability to sort selections, either ascending or descending. This is helpful to ensure that certain things are sorted correctly and useful for tables, in fact the reason I created this is due to the manual difficulty I was having when trying to sort language and locale tables for Speech service docs. I really could have used this feature then :smile:.

## Sort selection
![sort-selected-lines](https://user-images.githubusercontent.com/7679720/73078787-8cfbad80-3e88-11ea-91f9-b59ce41fcd98.gif)

> **Note:** the menu item is only ever available when the editor has a selection.

When testing this locally, feel free to use this markdown -- or any other variation.

```markdown
| Letter | Details |
|--------|---------|
| Z | The last letter in the alphabet |
| C | The a letter after A in the alphabet |
| X | The alphabet letter is towards the end |
| M | Somewhere in the middle? |
| A | The first letter in the alphabet |
```