### PR TITLE
Added implicit metadata updates

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -201,8 +201,8 @@
         "category": "Docs"
       },
       {
-        "command": "updateAllMetadataValues",
-        "title": "Update All Metadata Values",
+        "command": "updateImplicitMetadataValues",
+        "title": "Update Implicit Metadata Values",
         "category": "Docs"
       }
     ],

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -179,8 +179,8 @@
         "category": "Docs"
       },
       {
-        "command": "updateAllMetadataValues",
-        "title": "Update All Metadata Value",
+        "command": "updateImplicitMetadataValues",
+        "title": "Update Implicit Metadata Values",
         "category": "Docs"
       },
       {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -179,6 +179,11 @@
         "category": "Docs"
       },
       {
+        "command": "updateAllMetadataValues",
+        "title": "Update All Metadata Value",
+        "category": "Docs"
+      },
+      {
         "command": "sortSelectionAscending",
         "title": "Sort selection ascending (A to Z)",
         "category": "Docs",
@@ -193,6 +198,11 @@
       {
         "command": "insertLanguageIdentifier",
         "title": "Insert language identifier",
+        "category": "Docs"
+      },
+      {
+        "command": "updateAllMetadataValues",
+        "title": "Update All Metadata Values",
         "category": "Docs"
       }
     ],
@@ -209,6 +219,11 @@
         {
           "when": "resourceLangId == markdown",
           "command": "updateMetadataDate",
+          "group": "1_modification"
+        },
+        {
+          "when": "resourceLangId == markdown",
+          "command": "updateAllMetadataValues",
           "group": "1_modification"
         },
         {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -181,7 +181,8 @@
       {
         "command": "updateImplicitMetadataValues",
         "title": "Update Implicit Metadata Values",
-        "category": "Docs"
+        "category": "Docs",
+        "enablement": "resourceLangId == markdown"
       },
       {
         "command": "sortSelectionAscending",
@@ -203,7 +204,8 @@
       {
         "command": "updateImplicitMetadataValues",
         "title": "Update Implicit Metadata Values",
-        "category": "Docs"
+        "category": "Docs",
+        "enablement": "resourceLangId == markdown"
       }
     ],
     "menus": {
@@ -217,13 +219,13 @@
       ],
       "editor/context": [
         {
-          "when": "resourceLangId == markdown",
+          "when": "editorTextFocus",
           "command": "updateMetadataDate",
           "group": "1_modification"
         },
         {
-          "when": "resourceLangId == markdown",
-          "command": "updateAllMetadataValues",
+          "when": "editorTextFocus",
+          "command": "updateImplicitMetadataValues",
           "group": "1_modification"
         },
         {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {

--- a/docs-markdown/src/controllers/metadata-controller.ts
+++ b/docs-markdown/src/controllers/metadata-controller.ts
@@ -9,7 +9,39 @@ export function insertMetadataCommands() {
     ];
 }
 
+const authorRegex = /\Aauthor:\s*\b(.+?)$/mi;
+const msAuthorRegex = /ms.author:\s*\b(.+?)$/mi;
 const msDateRegex = /ms.date:\s*\b(.+?)$/mi;
+const msServiceRegex = /ms.service:\s*\b(.+?)$/mi;
+const msSubserviceRegex = /ms.subservice:\s*\b(.+?)$/mi;
+const metadataExpressions = [
+    authorRegex,
+    msAuthorRegex,
+    msDateRegex,
+    msServiceRegex,
+    msSubserviceRegex,
+];
+
+export async function updateAllMetadataValues() {
+    const editor = window.activeTextEditor;
+    if (!editor) {
+        noActiveEditorMessage();
+        return;
+    }
+
+    if (!isMarkdownFileCheck(editor, false)) {
+        return;
+    }
+
+    const content = editor.document.getText();
+    if (content) {
+        metadataExpressions.forEach((exp) => {
+
+        });
+    }
+}
+
+
 
 export async function updateMetadataDate() {
     const editor = window.activeTextEditor;
@@ -40,14 +72,18 @@ export async function updateMetadataDate() {
                 });
 
                 if (wasEdited) {
-                    await commands.executeCommand("workbench.action.files.save");
-
-                    const telemetryCommand = "updateMetadata";
-                    sendTelemetryData(telemetryCommand, updateMetadataDate.name);
+                    saveAndSendTelemetry();
                 }
             }
         }
     }
+}
+
+async function saveAndSendTelemetry() {
+    await commands.executeCommand("workbench.action.files.save");
+
+    const telemetryCommand = "updateMetadata";
+    sendTelemetryData(telemetryCommand, updateMetadataDate.name);
 }
 
 function toShortDate(date: Date) {

--- a/docs-markdown/src/controllers/metadata-controller.ts
+++ b/docs-markdown/src/controllers/metadata-controller.ts
@@ -1,10 +1,10 @@
 "use strict";
 
 import * as fs from "fs";
-import * as path from "path";
 import * as glob from "glob";
+import * as path from "path";
 
-import { commands, Selection, TextEditor, window, workspace } from "vscode";
+import { commands, Selection, TextEditor, window, workspace, TextEdit } from "vscode";
 import { isMarkdownFileCheck, noActiveEditorMessage, sendTelemetryData } from "../helper/common";
 
 export function insertMetadataCommands() {
@@ -33,9 +33,24 @@ interface IDocFxMetadata {
     };
 }
 
-interface ReplacementFormat {
-    format: string;
+type MetadataType = "author" | "ms.author" | "ms.date" | "ms.service" | "ms.subservice";
+
+interface Replacement {
+    selection: Selection;
     value: string;
+}
+
+type Replacements = Replacement[];
+
+class ReplacementFormat {
+    constructor(
+        readonly type: MetadataType,
+        private readonly value: string) {
+    }
+
+    public toReplacementString() {
+        return `${this.type}: ${this.value}`;
+    }
 }
 
 const authorRegex = /\Aauthor:\s*\b(.+?)$/mi;
@@ -43,13 +58,14 @@ const msAuthorRegex = /ms.author:\s*\b(.+?)$/mi;
 const msDateRegex = /ms.date:\s*\b(.+?)$/mi;
 const msServiceRegex = /ms.service:\s*\b(.+?)$/mi;
 const msSubserviceRegex = /ms.subservice:\s*\b(.+?)$/mi;
-const metadataExpressions = [
-    authorRegex,
-    msAuthorRegex,
-    msDateRegex,
-    msServiceRegex,
-    msSubserviceRegex,
-];
+
+const metadataExpressions: Map<MetadataType, RegExp> = new Map([
+    ["author", authorRegex],
+    ["ms.author", msAuthorRegex],
+    ["ms.date", msDateRegex],
+    ["ms.service", msServiceRegex],
+    ["ms.subservice", msSubserviceRegex],
+]);
 
 export async function updateAllMetadataValues() {
     const editor = window.activeTextEditor;
@@ -64,32 +80,132 @@ export async function updateAllMetadataValues() {
 
     const content = editor.document.getText();
     if (content) {
-        const replacements = await getMetadataReplacements(editor);
-        if (replacements) {
-            metadataExpressions.forEach((exp) => {
-                if (exp) {
-                    global.console.log(exp);
+        const replacementFormats = await getMetadataReplacements(editor);
+        if (replacementFormats) {
+            const replacements: Replacements = [];
+            for (let i = 0; i < replacementFormats.length; ++i) {
+                const replacementFormat = replacementFormats[i];
+                if (replacementFormat) {
+                    const expression = metadataExpressions.get(replacementFormat.type);
+                    const replacement = findReplacement(editor, content, replacementFormat.toReplacementString(), expression);
+                    if (replacement) {
+                        replacements.push(replacement);
+                    }
                 }
-            });
+            }
+
+            applyReplacements(replacements, editor);
+            saveAndSendTelemetry();
         }
+    }
+}
+
+function findReplacement(editor: TextEditor, content: string, value: string, expression?: RegExp): Replacement | undefined {
+    const result = expression ? expression.exec(content) : null;
+    if (result !== null && result.length) {
+        const match = result[0];
+        if (match) {
+            const index = result.index;
+            const startPosition = editor.document.positionAt(index);
+            const endPosition = editor.document.positionAt(index + match.length);
+            const selection = new Selection(startPosition, endPosition);
+
+            return { selection, value };
+        }
+    }
+
+    return undefined;
+}
+
+function applyReplacements(replacements: Replacements, editor: TextEditor) {
+    if (replacements) {
+        replacements.forEach(async (replacement) => {
+            await editor.edit((builder) => {
+                builder.replace(
+                    replacement.selection,
+                    replacement.value);
+            });
+        });
     }
 }
 
 async function getMetadataReplacements(editor: TextEditor): Promise<ReplacementFormat[]> {
     const folder = workspace.getWorkspaceFolder(editor.document.uri);
     if (folder) {
+        // Read the DocFX.json file, search for metadata defaults.
         const docFxJson = tryFindDocFxJsonFile(folder.uri.fsPath);
         if (!!docFxJson && fs.existsSync(docFxJson)) {
             const jsonBuffer = fs.readFileSync(docFxJson);
             const metadata = JSON.parse(jsonBuffer.toString()) as IDocFxMetadata;
             if (metadata && metadata.build && metadata.build.fileMetadata) {
-                return [];
+                const replacements: ReplacementFormat[] = [];
+                const fsPath = editor.document.uri.fsPath;
+                const fileMetadata = metadata.build.fileMetadata;
+                const tryAssignReplacement = (filePath: string, type: MetadataType, globs?: { [glob: string]: string }) => {
+                    if (globs) {
+                        const value = getReplacementValue(globs, filePath);
+                        if (value) {
+                            replacements.push(new ReplacementFormat(type, value));
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+
+                // Fall back to templates config, if unable to find author and ms.author
+                if (!tryAssignReplacement(fsPath, "author", fileMetadata.author)) {
+                    const gitHubId = workspace.getConfiguration("docs.templates").githubid;
+                    if (gitHubId) {
+                        replacements.push(new ReplacementFormat("author", gitHubId));
+                    }
+                }
+                if (!tryAssignReplacement(fsPath, "ms.author", fileMetadata["ms.author"])) {
+                    const alias = workspace.getConfiguration("docs.templates").alias;
+                    if (alias) {
+                        replacements.push(new ReplacementFormat("ms.author", alias));
+                    }
+                }
+                tryAssignReplacement(fsPath, "ms.service", fileMetadata["ms.service"]);
+                tryAssignReplacement(fsPath, "ms.subservice", fileMetadata["ms.subservice"]);
+
+                replacements.push(new ReplacementFormat("ms.date", toShortDate(new Date())));
+
+                return replacements;
             }
         }
     }
-    // const fileName = editor.document.fileName;
 
     return [];
+}
+
+function getReplacementValue(globs: { [glob: string]: string }, fsPath: string): string | undefined {
+    if (globs && fsPath) {
+        let segments = fsPath.split(path.sep);
+        const globKeys = Object.keys(globs).map((key) => ({ key, segments: key.split("/") }));
+        const firstSegment = globKeys[0].segments[0];
+        segments = segments.slice(segments.indexOf(firstSegment));
+        const length = segments.length;
+        for (let i = 0; i < globKeys.length; ++i) {
+            const globKey = globKeys[i];
+            if (length <= globKey.segments.length) {
+                let equals = false;
+                for (let f = 0; f < segments.length - 1; ++f) {
+                    const left = segments[f];
+                    const right = globKey.segments[f];
+                    if (right.startsWith("*")) {
+                        break;
+                    }
+                    equals = left.toLowerCase() === right.toLowerCase();
+                }
+
+                if (equals) {
+                    return globs[globKey.key];
+                }
+            }
+        }
+    }
+
+    return undefined;
 }
 
 function tryFindDocFxJsonFile(rootPath: string) {
@@ -123,31 +239,13 @@ export async function updateMetadataDate() {
 
     const content = editor.document.getText();
     if (content) {
-        const result = msDateRegex.exec(content);
-        let wasEdited = false;
-        if (result !== null && result.length) {
-            const match = result[0];
-            if (match) {
-                const index = result.index;
-                wasEdited = await editor.edit((builder) => {
-                    const startPosition = editor.document.positionAt(index);
-                    const endPosition = editor.document.positionAt(index + match.length);
-                    const selection = new Selection(startPosition, endPosition);
-
-                    builder.replace(
-                        selection,
-                        `ms.date: ${toShortDate(new Date())}`);
-                });
-            }
-        }
-
-        if (wasEdited) {
+        const replacement = findReplacement(editor, content, `ms.date: ${toShortDate(new Date())}`, msDateRegex);
+        if (replacement) {
+            applyReplacements([replacement], editor);
             saveAndSendTelemetry();
         }
     }
 }
-
-
 
 async function saveAndSendTelemetry() {
     await commands.executeCommand("workbench.action.files.save");

--- a/docs-markdown/tsconfig.json
+++ b/docs-markdown/tsconfig.json
@@ -10,6 +10,7 @@
         "noImplicitThis": true,
         "lib": [
             "es6",
+            "es2017.object"
         ],
         "sourceMap": true,
         "rootDir": "."

--- a/docs-markdown/tsconfig.json
+++ b/docs-markdown/tsconfig.json
@@ -9,8 +9,7 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "lib": [
-            "es6",
-            "es2017.object"
+            "es6"
         ],
         "sourceMap": true,
         "rootDir": "."


### PR DESCRIPTION
Hi @meganbradley,

I've got another nice-to-have feature that will hopefully help to increase content development productivity. I just wanted to add a note here explaining how appreciative I am of this amazing platform, for being so accepting of contributions and supportive. I feels great to collaborate on these kinds of things!

See details below:

Watch this short GIF, that demonstrates this new functionality. Notice the various metadata values, such as the `titleSuffix`, `author`, `manager`, `ms.service`, `ms.subservice`, `ms.date` and `ms.author`. All of these values are discoverable in the workspace `docfx.json` if specified. If they are not found there, the `author` and `ms.author` are pulled from the templates config. What this means, is that for repos that have configured implicit metadata values -- authors can now trigger implicit metadata updates if the metadata values are explicitly set to something different.

## Update Implicit Metadata Values

![implicit-metadata-updates](https://user-images.githubusercontent.com/7679720/73462200-025ff600-4341-11ea-9caf-b6e1789b2458.gif)

### Notes

This design is based on the [`docfx.json` file format](https://dotnet.github.io/docfx/tutorial/docfx.exe_user_manual.html#3-docfxjson-format) and executes on a discovery-based approach. When there is a `docfx.json` file present, we parse it, and evaluate various metadata values. These values are then used as potential replacements, the reason they're only potential replacements is that we only replace metadata values that are present in the contextual markdown file.