### PR TITLE
Add .NET Core CLI dev lang to highlight languages list

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.2.44",
+  "version": "0.2.45",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {

--- a/docs-markdown/src/helper/highlight-langs.ts
+++ b/docs-markdown/src/helper/highlight-langs.ts
@@ -41,6 +41,7 @@ type HighlightLanguages = IHighlightLanguage[];
  */
 const languages: HighlightLanguages =
     [
+        { language: ".NET Core CLI", aliases: ["dotnetcli"], isPopular: true },
         { language: "1C", aliases: ["1c"] },
         { language: "ABNF", aliases: ["abnf"] },
         { language: "Access logs ", aliases: ["accesslog"] },


### PR DESCRIPTION
The `dotnetcli` dev lang was missing. Adding it in this PR and setting as popular so that it appears in the triple-tick autocomplete dialog. This dev lang is used extensively across multiple doc sets. Example: https://docs.microsoft.com/aspnet/core/client-side/libman/libman-cli?view=aspnetcore-3.1#installation