### PR TITLE
Added sorting of the master redirect file.

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.2.47",
+  "version": "0.2.49",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {
@@ -36,6 +36,11 @@
       {
         "command": "generateMasterRedirectionFile",
         "title": "Generate master redirection file",
+        "category": "Docs"
+      },
+      {
+        "command": "sortMasterRedirectionFile",
+        "title": "Sort master redirection file",
         "category": "Docs"
       },
       {
@@ -265,6 +270,10 @@
         },
         {
           "command": "generateMasterRedirectionFile",
+          "group": "Docs"
+        },
+        {
+          "command": "sortMasterRedirectionFile",
           "group": "Docs"
         },
         {

--- a/docs-markdown/src/controllers/metadata-controller.ts
+++ b/docs-markdown/src/controllers/metadata-controller.ts
@@ -1,11 +1,10 @@
 "use strict";
 
 import * as fs from "fs";
-import * as glob from "glob";
 import * as path from "path";
 
 import { commands, Selection, TextEditor, window, workspace } from "vscode";
-import { isMarkdownFileCheck, noActiveEditorMessage, sendTelemetryData } from "../helper/common";
+import { isMarkdownFileCheck, noActiveEditorMessage, sendTelemetryData, tryFindFile } from "../helper/common";
 
 export function insertMetadataCommands() {
     return [
@@ -149,7 +148,7 @@ async function getMetadataReplacements(editor: TextEditor): Promise<ReplacementF
     const folder = workspace.getWorkspaceFolder(editor.document.uri);
     if (folder) {
         // Read the DocFX.json file, search for metadata defaults.
-        const docFxJson = tryFindDocFxJsonFile(folder.uri.fsPath);
+        const docFxJson = tryFindFile(folder.uri.fsPath, "docfx.json");
         if (!!docFxJson && fs.existsSync(docFxJson)) {
             const jsonBuffer = fs.readFileSync(docFxJson);
             const metadata = JSON.parse(jsonBuffer.toString()) as IDocFxMetadata;
@@ -221,24 +220,6 @@ function getReplacementValue(globs: { [glob: string]: string }, fsPath: string):
                     return globs[globKey.key];
                 }
             }
-        }
-    }
-
-    return undefined;
-}
-
-function tryFindDocFxJsonFile(rootPath: string) {
-    const docFxJson = path.resolve(rootPath, "docfx.json");
-    const exists = fs.existsSync(docFxJson);
-    if (exists) {
-        return docFxJson;
-    } else {
-        const files = glob.sync("**/docfx.json", {
-            cwd: rootPath,
-        });
-
-        if (files && files.length === 1) {
-            return path.join(rootPath, files[0]);
         }
     }
 

--- a/docs-markdown/src/helper/common.ts
+++ b/docs-markdown/src/helper/common.ts
@@ -28,6 +28,7 @@ export function tryFindFile(rootPath: string, fileName: string) {
         postError(error.toString());
     }
 
+    postWarning(`Unable to find a file named "${fileName}", recursively at root "${rootPath}".`);
     return undefined;
 }
 

--- a/docs-markdown/src/helper/common.ts
+++ b/docs-markdown/src/helper/common.ts
@@ -1,11 +1,35 @@
 "use-strict";
 
-import os = require("os");
-import path = require("path");
+import * as fs from "fs";
+import * as glob from "glob";
+import * as os from "os";
+import * as path from "path";
 import * as vscode from "vscode";
 import { output } from "../extension";
 import * as log from "./log";
 import { reporter } from "./telemetry";
+
+export function tryFindFile(rootPath: string, fileName: string) {
+    try {
+        const fullPath = path.resolve(rootPath, fileName);
+        const exists = fs.existsSync(fullPath);
+        if (exists) {
+            return fullPath;
+        } else {
+            const files = glob.sync(`**/${fileName}`, {
+                cwd: rootPath,
+            });
+
+            if (files && files.length === 1) {
+                return path.join(rootPath, files[0]);
+            }
+        }
+    } catch (error) {
+        postError(error.toString());
+    }
+
+    return undefined;
+}
 
 /**
  * Provide current os platform


### PR DESCRIPTION
Hi @meganbradley,

Added the ability to sort the `.openpublishing.redirection.json` file. Open the command pallet and quickly sort the entire file alphabetically.

![sort-redirection](https://user-images.githubusercontent.com/7679720/74775131-af4fd380-525a-11ea-8650-c8e174e95690.gif)
