### PR TITLE
Added right-click, automatic formatting of markdown tables.

### DIFF
--- a/docs-markdown/.vscode/settings.json
+++ b/docs-markdown/.vscode/settings.json
@@ -7,21 +7,5 @@
         "out": true // set this to false to include "out" folder in search results
     },
     "typescript.tsdk": "node_modules/typescript/lib",
-    "editor.formatOnSave": true,
-    "workbench.colorCustomizations": {
-        "activityBar.background": "#d04649",
-        "activityBar.activeBorder": "#37cb34",
-        "activityBar.foreground": "#e7e7e7",
-        "activityBar.inactiveForeground": "#e7e7e799",
-        "activityBarBadge.background": "#37cb34",
-        "activityBarBadge.foreground": "#15202b",
-        "titleBar.activeBackground": "#b52e31",
-        "titleBar.inactiveBackground": "#b52e3199",
-        "titleBar.activeForeground": "#e7e7e7",
-        "titleBar.inactiveForeground": "#e7e7e799",
-        "statusBar.background": "#b52e31",
-        "statusBarItem.hoverBackground": "#d04649",
-        "statusBar.foreground": "#e7e7e7"
-    },
-    "peacock.color": "#b52e31" // we want to use the TS server from our node_modules folder to control its version
+    "editor.formatOnSave": true // we want to use the TS server from our node_modules folder to control its version
 }

--- a/docs-markdown/.vscode/settings.json
+++ b/docs-markdown/.vscode/settings.json
@@ -7,5 +7,21 @@
         "out": true // set this to false to include "out" folder in search results
     },
     "typescript.tsdk": "node_modules/typescript/lib",
-    "editor.formatOnSave": true // we want to use the TS server from our node_modules folder to control its version
+    "editor.formatOnSave": true,
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#d04649",
+        "activityBar.activeBorder": "#37cb34",
+        "activityBar.foreground": "#e7e7e7",
+        "activityBar.inactiveForeground": "#e7e7e799",
+        "activityBarBadge.background": "#37cb34",
+        "activityBarBadge.foreground": "#15202b",
+        "titleBar.activeBackground": "#b52e31",
+        "titleBar.inactiveBackground": "#b52e3199",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveForeground": "#e7e7e799",
+        "statusBar.background": "#b52e31",
+        "statusBarItem.hoverBackground": "#d04649",
+        "statusBar.foreground": "#e7e7e7"
+    },
+    "peacock.color": "#b52e31" // we want to use the TS server from our node_modules folder to control its version
 }

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.2.51",
+  "version": "0.2.52",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -79,8 +79,13 @@
         "category": "Docs"
       },
       {
-        "command": "formatTable",
-        "title": "Format Selected Table",
+        "command": "distributeTable",
+        "title": "Evenly distribute selected table",
+        "category": "Docs"
+      },
+      {
+        "command": "consolidateTable",
+        "title": "Consolidate selected table",
         "category": "Docs"
       },
       {
@@ -258,7 +263,12 @@
         },
         {
           "when": "editorHasSelection",
-          "command": "formatTable",
+          "command": "distributeTable",
+          "group": "1_modification"
+        },
+        {
+          "when": "editorHasSelection",
+          "command": "consolidateTable",
           "group": "1_modification"
         }
       ],
@@ -322,7 +332,12 @@
           "when": "resourceLangId == markdown"
         },
         {
-          "command": "formatTable",
+          "command": "distributeTable",
+          "group": "Docs",
+          "when": "resourceLangId == markdown"
+        },
+        {
+          "command": "consolidateTable",
           "group": "Docs",
           "when": "resourceLangId == markdown"
         },

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -79,6 +79,11 @@
         "category": "Docs"
       },
       {
+        "command": "formatTable",
+        "title": "Format Selected Table",
+        "category": "Docs"
+      },
+      {
         "command": "selectLinkType",
         "title": "Link to heading",
         "category": "Docs"
@@ -250,6 +255,11 @@
           "when": "editorHasSelection",
           "command": "sortSelectionDescending",
           "group": "1_modification"
+        },
+        {
+          "when": "editorHasSelection",
+          "command": "formatTable",
+          "group": "1_modification"
         }
       ],
       "explorer/context": [
@@ -308,6 +318,11 @@
         },
         {
           "command": "insertTable",
+          "group": "Docs",
+          "when": "resourceLangId == markdown"
+        },
+        {
+          "command": "formatTable",
           "group": "Docs",
           "when": "resourceLangId == markdown"
         },

--- a/docs-markdown/src/controllers/table-controller.ts
+++ b/docs-markdown/src/controllers/table-controller.ts
@@ -2,17 +2,36 @@
 
 import * as vscode from "vscode";
 import { output } from "../extension";
-import { insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage, sendTelemetryData } from "../helper/common";
+import { insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage, postWarning, sendTelemetryData } from "../helper/common";
+import { MarkdownTable } from "../helper/markdown-table";
 import { tableBuilder, validateTableRowAndColumnCount } from "../helper/utility";
 
 const telemetryCommand: string = "insertTable";
 let commandOption: string;
 
 export function insertTableCommand() {
-    const commands = [
+    return [
+        { command: formatTable.name, callback: formatTable },
         { command: insertTable.name, callback: insertTable },
     ];
-    return commands;
+}
+
+export async function formatTable() {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        noActiveEditorMessage();
+        return;
+    }
+    const selection = editor.selection;
+    if (!selection) {
+        postWarning("You must select a markdown table first.");
+        return;
+    }
+
+    const table = MarkdownTable.parse(selection, editor.document);
+    if (table) {
+        await table.reformat(editor);
+    }
 }
 
 export function insertTable() {

--- a/docs-markdown/src/controllers/table-controller.ts
+++ b/docs-markdown/src/controllers/table-controller.ts
@@ -3,7 +3,7 @@
 import * as vscode from "vscode";
 import { output } from "../extension";
 import { insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage, postWarning, sendTelemetryData } from "../helper/common";
-import { MarkdownTable } from "../helper/markdown-table";
+import { FormatOptions, MarkdownTable } from "../helper/markdown-table";
 import { tableBuilder, validateTableRowAndColumnCount } from "../helper/utility";
 
 const telemetryCommand: string = "insertTable";
@@ -11,12 +11,21 @@ let commandOption: string;
 
 export function insertTableCommand() {
     return [
-        { command: formatTable.name, callback: formatTable },
+        { command: consolidateTable.name, callback: consolidateTable },
+        { command: distributeTable.name, callback: distributeTable },
         { command: insertTable.name, callback: insertTable },
     ];
 }
 
-export async function formatTable() {
+export async function consolidateTable() {
+    await reformatTable(FormatOptions.Consolidate);
+}
+
+export async function distributeTable() {
+    await reformatTable(FormatOptions.Distribute);
+}
+
+async function reformatTable(formatOptions: FormatOptions) {
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
         noActiveEditorMessage();
@@ -30,7 +39,7 @@ export async function formatTable() {
 
     const table = MarkdownTable.parse(selection, editor.document);
     if (table) {
-        await table.reformat(editor);
+        await table.reformat(editor, formatOptions);
     }
 }
 

--- a/docs-markdown/src/helper/markdown-table.ts
+++ b/docs-markdown/src/helper/markdown-table.ts
@@ -1,0 +1,136 @@
+import { Selection, TextDocument, TextEditor } from "vscode";
+
+interface IndexLinePair {
+    index: number;
+    line: string;
+}
+
+enum ColumnAlignment {
+    None,
+    Left,
+    Center,
+    Right,
+}
+
+export class MarkdownTable {
+    public static parse(selection: Selection, document: TextDocument): MarkdownTable | null {
+        if (!selection || selection.isSingleLine || !document) {
+            return null;
+        }
+
+        const parseLine = (selection: Selection) => {
+            const startLine = selection.start.line;
+            // git const 
+            const textLine = document.lineAt(selection.start.line);
+            return textLine.text;
+        };
+
+        const map = new Map<IndexLinePair, Selection>();
+        selections.forEach((selection, index) => map.set({ index, line: parseLine(selection) }, selection));
+
+        return new MarkdownTable(map);
+    }
+
+    private constructor(private lines: ReadonlyMap<IndexLinePair, Selection>) { }
+
+    public async reformat(editor: TextEditor) {
+        const measureColumnSpan = (column: string) => {
+            const trimmed = column.trim();
+            return trimmed.length;
+        };
+
+        const parseColumnAlignment = (column: string) => {
+            const trimmed = column.trim();
+            if (trimmed.length > 0) {
+                const left = trimmed.startsWith(":");
+                const right = trimmed.endsWith(":");
+                if (left && right) {
+                    return ColumnAlignment.Center;
+                }
+                if (left) {
+                    return ColumnAlignment.Left;
+                }
+                if (right) {
+                    return ColumnAlignment.Right;
+                }
+            }
+
+            return ColumnAlignment.None;
+        };
+
+        let isFirstColumnSpace: boolean = false;
+        const columnSpanLengths = new Map<number, number>();
+        const columnAlignments = new Map<number, ColumnAlignment>();
+        this.lines.forEach((_, pair, map) => {
+            const { index, line } = pair;
+            const columns = line.split("|");
+            switch (index) {
+                case 0: // Table headings
+                    isFirstColumnSpace = measureColumnSpan(columns[0]) === 0;
+                    columns.forEach((col, i) => columnSpanLengths.set(i, measureColumnSpan(col)));
+                    break;
+                case 1: // Column formatting
+                    columns.forEach((col, i) => columnAlignments.set(i, parseColumnAlignment(col)));
+                    break;
+
+                default: // Remaining rows
+                    columns.forEach((col, i) => {
+                        const existingLength = columnSpanLengths.get(i) || 0;
+                        const currentLength = measureColumnSpan(col);
+                        if (!!existingLength && currentLength > existingLength) {
+                            columnSpanLengths.set(i, currentLength);
+                        }
+                    });
+                    break;
+            }
+        });
+
+        const replacements: Array<{ selection: Selection, value: string }> = [];
+        for (const [pair, selection] of this.lines) {
+            const { index, line } = pair;
+            const isAlignmentRow = index === 1;
+            const columns = line.split("|");
+            const isLastIteration = (i: number, array: string[]) => {
+                return i === array.length - 1;
+            };
+
+            let value = "";
+            for (let i = 0; i < columns.length; ++i) {
+                const column = columns[i];
+                if (isFirstColumnSpace) {
+                    value += column;
+                    continue;
+                }
+
+                const padding = columnSpanLengths.get(i) || 0;
+                const isLastColumn = isLastIteration(i, columns);
+                if (isAlignmentRow) {
+                    const columnAlignment = columnAlignments.get(i) || ColumnAlignment.None;
+                    switch (columnAlignment) {
+                        case ColumnAlignment.Center:
+                            value += `|:${"".padEnd(padding - 2, "-")}:`;
+                            if (isLastColumn) {
+                                value += " |";
+                            }
+                            break;
+                    }
+                    continue;
+                }
+
+                value += `| ${column.padEnd(padding)} `;
+                if (isLastColumn) {
+                    value += " |";
+                }
+            }
+
+            replacements.push({ selection, value });
+        }
+
+        await editor.edit((builder) => {
+            replacements.forEach((replacement) =>
+                builder.replace(
+                    replacement.selection,
+                    replacement.value));
+        });
+    }
+}

--- a/docs-markdown/src/helper/markdown-table.ts
+++ b/docs-markdown/src/helper/markdown-table.ts
@@ -1,10 +1,5 @@
 import { Selection, TextDocument, TextEditor } from "vscode";
 
-interface IndexLinePair {
-    index: number;
-    line: string;
-}
-
 enum ColumnAlignment {
     None,
     Left,
@@ -18,66 +13,48 @@ export class MarkdownTable {
             return null;
         }
 
-        const parseLine = (selection: Selection) => {
+        const parseLines = (s: Selection): string[] => {
             const startLine = selection.start.line;
-            // git const 
-            const textLine = document.lineAt(selection.start.line);
-            return textLine.text;
+            const endLine = selection.end.line;
+            const lines: string[] = [];
+            for (let line = startLine; line <= endLine; ++line) {
+                lines.push(document.lineAt(line).text);
+            }
+            return lines;
         };
 
-        const map = new Map<IndexLinePair, Selection>();
-        selections.forEach((selection, index) => map.set({ index, line: parseLine(selection) }, selection));
-
-        return new MarkdownTable(map);
+        return new MarkdownTable(selection, parseLines(selection));
     }
 
-    private constructor(private lines: ReadonlyMap<IndexLinePair, Selection>) { }
+    private readonly emojiRegex: RegExp =
+        /(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|\ud83c[\ude32-\ude3a]|\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/g;
+
+    private constructor(
+        private readonly selection: Selection,
+        private readonly lines: string[]) { }
 
     public async reformat(editor: TextEditor) {
-        const measureColumnSpan = (column: string) => {
-            const trimmed = column.trim();
-            return trimmed.length;
-        };
-
-        const parseColumnAlignment = (column: string) => {
-            const trimmed = column.trim();
-            if (trimmed.length > 0) {
-                const left = trimmed.startsWith(":");
-                const right = trimmed.endsWith(":");
-                if (left && right) {
-                    return ColumnAlignment.Center;
-                }
-                if (left) {
-                    return ColumnAlignment.Left;
-                }
-                if (right) {
-                    return ColumnAlignment.Right;
-                }
-            }
-
-            return ColumnAlignment.None;
-        };
-
         let isFirstColumnSpace: boolean = false;
         const columnSpanLengths = new Map<number, number>();
         const columnAlignments = new Map<number, ColumnAlignment>();
-        this.lines.forEach((_, pair, map) => {
-            const { index, line } = pair;
-            const columns = line.split("|");
+
+        this.lines.forEach((line, index, _) => {
+            const columns = this.parseTableRow(line);
             switch (index) {
                 case 0: // Table headings
-                    isFirstColumnSpace = measureColumnSpan(columns[0]) === 0;
-                    columns.forEach((col, i) => columnSpanLengths.set(i, measureColumnSpan(col)));
+                    const columnZero = columns[0];
+                    isFirstColumnSpace = columnZero !== "" && this.measureColumnSpan(columnZero) === 0;
+                    columns.forEach((col, i) => columnSpanLengths.set(i, this.measureColumnSpan(col)));
                     break;
                 case 1: // Column formatting
-                    columns.forEach((col, i) => columnAlignments.set(i, parseColumnAlignment(col)));
+                    columns.forEach((col, i) => columnAlignments.set(i, this.parseColumnAlignment(col)));
                     break;
 
                 default: // Remaining rows
                     columns.forEach((col, i) => {
-                        const existingLength = columnSpanLengths.get(i) || 0;
-                        const currentLength = measureColumnSpan(col);
-                        if (!!existingLength && currentLength > existingLength) {
+                        const existingLength = columnSpanLengths.has(i) ? columnSpanLengths.get(i) : -1;
+                        const currentLength = this.measureColumnSpan(col);
+                        if (existingLength !== -1 && currentLength > (existingLength || 0)) {
                             columnSpanLengths.set(i, currentLength);
                         }
                     });
@@ -85,20 +62,19 @@ export class MarkdownTable {
             }
         });
 
-        const replacements: Array<{ selection: Selection, value: string }> = [];
-        for (const [pair, selection] of this.lines) {
-            const { index, line } = pair;
+        const values: string[] = [];
+        this.lines.forEach((line, index, _) => {
             const isAlignmentRow = index === 1;
-            const columns = line.split("|");
+            const columns = this.parseTableRow(line);
             const isLastIteration = (i: number, array: string[]) => {
                 return i === array.length - 1;
             };
 
             let value = "";
             for (let i = 0; i < columns.length; ++i) {
-                const column = columns[i];
-                if (isFirstColumnSpace) {
-                    value += column;
+                const column = columns[i].trim();
+                if (i === 0 && isFirstColumnSpace) {
+                    value += columns[i];
                     continue;
                 }
 
@@ -108,29 +84,78 @@ export class MarkdownTable {
                     const columnAlignment = columnAlignments.get(i) || ColumnAlignment.None;
                     switch (columnAlignment) {
                         case ColumnAlignment.Center:
-                            value += `|:${"".padEnd(padding - 2, "-")}:`;
-                            if (isLastColumn) {
-                                value += " |";
-                            }
+                            value += `|:${"-".padEnd(padding, "-")}:`;
+                            break;
+                        case ColumnAlignment.Left:
+                            value += `|:${"-".padEnd(padding + 1, "-")}`;
+                            break;
+                        case ColumnAlignment.Right:
+                            value += `|${"-".padEnd(padding + 1, "-")}:`;
+                            break;
+                        case ColumnAlignment.None:
+                            value += `|${"-".padEnd(padding + 2, "-")}`;
                             break;
                     }
-                    continue;
+                } else {
+                    const emojiCount = this.countEmoji(column);
+                    value += `| ${column.padEnd(padding - emojiCount)} `;
                 }
 
-                value += `| ${column.padEnd(padding)} `;
                 if (isLastColumn) {
-                    value += " |";
+                    value += "|";
                 }
             }
 
-            replacements.push({ selection, value });
-        }
+            values.push(value);
+        });
 
         await editor.edit((builder) => {
-            replacements.forEach((replacement) =>
-                builder.replace(
-                    replacement.selection,
-                    replacement.value));
+            builder.replace(this.selection, values.join("\n"));
         });
+    }
+
+    private measureColumnSpan(column: string) {
+        const trimmed = column.trim();
+        return Array.from(trimmed.split(/[\ufe00-\ufe0f]/).join("")).length;
+    }
+
+    private parseColumnAlignment(column: string) {
+        const trimmed = column.trim();
+        if (trimmed.length > 0) {
+            const left = trimmed.startsWith(":");
+            const right = trimmed.endsWith(":");
+            if (left && right) {
+                return ColumnAlignment.Center;
+            }
+            if (left) {
+                return ColumnAlignment.Left;
+            }
+            if (right) {
+                return ColumnAlignment.Right;
+            }
+        }
+
+        return ColumnAlignment.None;
+    }
+
+    private parseTableRow(line: string): string[] {
+        let columns = line.split("|");
+        if (columns[0] === "") {
+            columns = columns.slice(1);
+        }
+        if (columns[columns.length - 1] === "") {
+            columns.pop();
+        }
+
+        return columns;
+    }
+
+    private countEmoji(value: string): number {
+        if (value) {
+            const result = this.emojiRegex.exec(value);
+            return result ? result.length : 0;
+        }
+
+        return 0;
     }
 }

--- a/docs-markdown/tsconfig.json
+++ b/docs-markdown/tsconfig.json
@@ -9,7 +9,8 @@
         "noImplicitAny": true,
         "noImplicitThis": true,
         "lib": [
-            "es6"
+            "es6",
+            "es2017"
         ],
         "sourceMap": true,
         "rootDir": "."


### PR DESCRIPTION
Hi @meganbradley,

I added the ability to format a selected markdown table. This will evenly distribute the tables columns making it more readable and at a glance more clearly indicate the number of columns, etc. This feature correctly maintains both the column alignment and table position indentation.

![format-table](https://user-images.githubusercontent.com/7679720/75037684-5a8aa380-547a-11ea-8c63-dc3bc8d1c5d8.gif)
