### PR TITLE
Added the ability to replace smart quotes in markdown files.

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -463,7 +463,7 @@
         "markdown.replaceSmartQuotes": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "When `true`, automatically replace smart quotes (`“, ”, ‘, and ’`) such as those found in Word documents - with standard quotes (`\" and '`) in markdown files."
+          "markdownDescription": "When `true`, automatically replace smart quotes (`“, ”, ‘, and ’`) such as those found in Word documents - with standard quotes (`\" and '`) in markdown files. This feature extends to other characters as well, i.e.; `©, ™, ®, and •` as well as subscript and superscript."
         },
         "markdown.allAvailableLanguages": {
           "type": "boolean",

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -463,7 +463,7 @@
         "markdown.replaceSmartQuotes": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "When `true`, automatically replace smart quotes (`“, ”, ‘, and ’`) such as those found in Word documents - with standard quotes (`\" and '`) in markdown files. This feature extends to other characters as well, i.e.; `©, ™, ®, and •` as well as subscript and superscript."
+          "markdownDescription": "When `true`, automatically replace smart quotes (`“, ”, ‘, and ’`) with standard quotes (`\" and '`) in markdown files. This feature extends to other characters as well, i.e.; (`©, ™, ®, •`, subscript and superscript characters). This is useful when pasting text from Word documents."
         },
         "markdown.allAvailableLanguages": {
           "type": "boolean",

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -460,6 +460,11 @@
       "type": "object",
       "title": "Docs Markdown Extension Configuration",
       "properties": {
+        "markdown.replaceSmartQuotes": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "When `true`, automatically replace smart quotes (`“, ”, ‘, and ’`) such as those found in Word documents - with standard quotes (`\" and '`) in markdown files."
+        },
         "markdown.allAvailableLanguages": {
           "type": "boolean",
           "default": false,

--- a/docs-markdown/src/controllers/metadata-controller.ts
+++ b/docs-markdown/src/controllers/metadata-controller.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 
 import { commands, TextEditor, window, workspace } from "vscode";
 import { isMarkdownFileCheck, noActiveEditorMessage, sendTelemetryData, tryFindFile } from "../helper/common";
-import { Replacements, findReplacement, applyReplacements } from "../helper/utility";
+import { applyReplacements, findReplacement, Replacements } from "../helper/utility";
 
 export function insertMetadataCommands() {
     return [

--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -34,6 +34,7 @@ import { Reporter } from "./helper/telemetry";
 import { UiHelper } from "./helper/ui";
 import { isCursorInsideYamlHeader } from "./helper/yaml-metadata";
 import { insertSortSelectionCommands } from "./controllers/sort-controller";
+import { replaceSmartQuotes } from "./helper/utility";
 
 export const output = window.createOutputChannel("docs-markdown");
 export let extensionPath: string;
@@ -107,17 +108,20 @@ export function activate(context: ExtensionContext) {
     vscode.languages.registerCompletionItemProvider("markdown", markdownCompletionItemsProvider, "`");
     vscode.languages.registerCodeActionsProvider("markdown", markdownCodeActionProvider);
 
+    // When the document changes, search and replace smart quotes if found.
+    vscode.workspace.onDidChangeTextDocument(replaceSmartQuotes);
+
     // Telemetry
     context.subscriptions.push(new Reporter(context));
 
     // Attempts the registration of commands with VS Code and then add them to the extension context.
     try {
-        vscode.commands.registerCommand('cleanupFile', async (uri: Uri) => {
+        vscode.commands.registerCommand("cleanupFile", async (uri: Uri) => {
             await applyCleanupFile(uri);
-        })
-        vscode.commands.registerCommand('cleanupInFolder', async (uri: Uri) => {
+        });
+        vscode.commands.registerCommand("cleanupInFolder", async (uri: Uri) => {
             await applyCleanupFolder(uri);
-        })
+        });
         AuthoringCommands.map((cmd: any) => {
             const commandName = cmd.command;
             const command = commands.registerCommand(commandName, cmd.callback);
@@ -131,9 +135,7 @@ export function activate(context: ExtensionContext) {
 
     // if the user changes markdown.showToolbar in settings.json, display message telling them to reload.
     workspace.onDidChangeConfiguration((e: any) => {
-
         if (e.affectsConfiguration("markdown.showToolbar")) {
-
             window.showInformationMessage("Your updated configuration has been recorded, but you must reload to see its effects.", "Reload")
                 .then((res) => {
                     if (res === "Reload") {

--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -6,8 +6,7 @@
  Logging, Error Handling, VS Code window updates, etc.
 */
 
-import { CancellationToken, commands, CompletionItem, ConfigurationTarget, ExtensionContext, languages, TextDocument, Uri, window, workspace } from "vscode";
-import * as vscode from "vscode";
+import { CancellationToken, commands, CompletionItem, ConfigurationTarget, ExtensionContext, languages, TextDocument, Uri, window, workspace, DocumentLink } from "vscode";
 import { insertAlertCommand } from "./controllers/alert-controller";
 import { boldFormattingCommand } from "./controllers/bold-controller";
 import { applyCleanupCommand, applyCleanupFile, applyCleanupFolder } from "./controllers/cleanup/cleanup-controller";
@@ -33,7 +32,7 @@ import { checkExtension, extractDocumentLink, generateTimestamp, matchAll, noAct
 import { insertLanguageCommands, markdownCodeActionProvider, markdownCompletionItemsProvider } from "./helper/highlight-langs";
 import { Reporter } from "./helper/telemetry";
 import { UiHelper } from "./helper/ui";
-import { replaceSmartQuotes } from "./helper/utility";
+import { findAndReplaceTargetExpressions } from "./helper/utility";
 import { isCursorInsideYamlHeader } from "./helper/yaml-metadata";
 
 export const output = window.createOutputChannel("docs-markdown");
@@ -90,11 +89,11 @@ export function activate(context: ExtensionContext) {
     insertLanguageCommands().forEach((cmd) => AuthoringCommands.push(cmd));
     // Autocomplete
     context.subscriptions.push(setupAutoComplete());
-    vscode.languages.registerDocumentLinkProvider({ language: "markdown" }, {
+    languages.registerDocumentLinkProvider({ language: "markdown" }, {
         provideDocumentLinks(document: TextDocument, token: CancellationToken) {
             const IMAGE_SOURCE_RE = /source="(.*?)"/gm;
             const text = document.getText();
-            const results: vscode.DocumentLink[] = [];
+            const results: DocumentLink[] = [];
             for (const match of matchAll(IMAGE_SOURCE_RE, text)) {
                 const matchLink = extractDocumentLink(document, match[1], match.index);
                 if (matchLink) {
@@ -105,21 +104,21 @@ export function activate(context: ExtensionContext) {
         },
     });
 
-    vscode.languages.registerCompletionItemProvider("markdown", markdownCompletionItemsProvider, "`");
-    vscode.languages.registerCodeActionsProvider("markdown", markdownCodeActionProvider);
+    languages.registerCompletionItemProvider("markdown", markdownCompletionItemsProvider, "`");
+    languages.registerCodeActionsProvider("markdown", markdownCodeActionProvider);
 
-    // When the document changes, search and replace smart quotes if found.
-    vscode.workspace.onDidChangeTextDocument(replaceSmartQuotes);
+    // When the document changes, find and replace target expressions (for example, smart quotes).
+    workspace.onDidChangeTextDocument(findAndReplaceTargetExpressions);
 
     // Telemetry
     context.subscriptions.push(new Reporter(context));
 
     // Attempts the registration of commands with VS Code and then add them to the extension context.
     try {
-        vscode.commands.registerCommand("cleanupFile", async (uri: Uri) => {
+        commands.registerCommand("cleanupFile", async (uri: Uri) => {
             await applyCleanupFile(uri);
         });
-        vscode.commands.registerCommand("cleanupInFolder", async (uri: Uri) => {
+        commands.registerCommand("cleanupInFolder", async (uri: Uri) => {
             await applyCleanupFolder(uri);
         });
         AuthoringCommands.map((cmd: any) => {

--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -6,7 +6,7 @@
  Logging, Error Handling, VS Code window updates, etc.
 */
 
-import { CancellationToken, commands, CompletionItem, ConfigurationTarget, ExtensionContext, languages, TextDocument, window, workspace, Uri } from "vscode";
+import { CancellationToken, commands, CompletionItem, ConfigurationTarget, ExtensionContext, languages, TextDocument, Uri, window, workspace } from "vscode";
 import * as vscode from "vscode";
 import { insertAlertCommand } from "./controllers/alert-controller";
 import { boldFormattingCommand } from "./controllers/bold-controller";
@@ -25,6 +25,7 @@ import { previewTopicCommand } from "./controllers/preview-controller";
 import { quickPickMenuCommand } from "./controllers/quick-pick-menu-controller";
 import { insertRowsAndColumnsCommand } from "./controllers/row-columns-controller";
 import { insertSnippetCommand } from "./controllers/snippet-controller";
+import { insertSortSelectionCommands } from "./controllers/sort-controller";
 import { insertTableCommand } from "./controllers/table-controller";
 import { applyXrefCommand } from "./controllers/xref-controller";
 import { yamlCommands } from "./controllers/yaml-controller";
@@ -32,9 +33,8 @@ import { checkExtension, extractDocumentLink, generateTimestamp, matchAll, noAct
 import { insertLanguageCommands, markdownCodeActionProvider, markdownCompletionItemsProvider } from "./helper/highlight-langs";
 import { Reporter } from "./helper/telemetry";
 import { UiHelper } from "./helper/ui";
-import { isCursorInsideYamlHeader } from "./helper/yaml-metadata";
-import { insertSortSelectionCommands } from "./controllers/sort-controller";
 import { replaceSmartQuotes } from "./helper/utility";
+import { isCursorInsideYamlHeader } from "./helper/yaml-metadata";
 
 export const output = window.createOutputChannel("docs-markdown");
 export let extensionPath: string;

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -307,28 +307,23 @@ export function createChildProcess(path: any, args: any, options: any) {
     return childProcess;
 }
 
-const leftDblSmartQuoteRegExp = /\u201c/gm;    // “
-const rightDblSmartQuoteRegExp = /\u201d/gm;    // ”
-const leftSglSmartQuoteRegExp = /\u2018/gm;    // ‘
-const rightSglSmartQuoteRegExp = /\u2019/gm;    // ’
-
-interface IQuoteReplacement {
+interface IExpressionReplacementPair {
     expression: RegExp;
     replacement: string;
 }
 
-const smartQuoteToStandardMap: IQuoteReplacement[] = [
-    { expression: leftDblSmartQuoteRegExp, replacement: '"' },
-    { expression: rightDblSmartQuoteRegExp, replacement: '"' },
-    { expression: leftSglSmartQuoteRegExp, replacement: "'" },
-    { expression: rightSglSmartQuoteRegExp, replacement: "'" },
+const expressionToReplacementMap: IExpressionReplacementPair[] = [
+    { expression: /\u201c/gm /* double left quote  “ */, replacement: '"' },
+    { expression: /\u201d/gm /* double right quote ” */, replacement: '"' },
+    { expression: /\u2018/gm /* single left quote  ‘ */, replacement: "'" },
+    { expression: /\u2019/gm /* single right quote ’ */, replacement: "'" },
 ];
 
 /**
- * Replaces smart quotes (`“, ”, ‘, and ’` such as those found in Word documents) with standard quotes.
- * @param event the event fired.
+ * Finds and replaces target expressions. For example, smart quotes (`“, ”, ‘, and ’` such as those found in Word documents) with standard quotes.
+ * @param event the event fired when a text document is changed.
  */
-export async function replaceSmartQuotes(event: TextDocumentChangeEvent) {
+export async function findAndReplaceTargetExpressions(event: TextDocumentChangeEvent) {
     if (!workspace.getConfiguration("markdown").replaceSmartQuotes) {
         return;
     }
@@ -340,7 +335,7 @@ export async function replaceSmartQuotes(event: TextDocumentChangeEvent) {
             const content = document.getText();
             if (!!content) {
                 const replacements: Replacements = [];
-                smartQuoteToStandardMap.forEach((quoteReplacement: IQuoteReplacement) => {
+                expressionToReplacementMap.forEach((quoteReplacement: IExpressionReplacementPair) => {
                     const replacement = findReplacement(document, content, quoteReplacement.replacement, quoteReplacement.expression);
                     if (replacement) {
                         replacements.push(replacement);

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -419,7 +419,7 @@ export function findReplacements(document: TextDocument, content: string, value:
         if (result !== null && result.length) {
             const match = result[0];
             if (match) {
-                const index = result.index ?? -1;
+                const index = result.index !== undefined ? result.index : -1;
                 if (index === -1) {
                     continue;
                 }

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -419,7 +419,7 @@ export function findReplacements(document: TextDocument, content: string, value:
         if (result !== null && result.length) {
             const match = result[0];
             if (match) {
-                const index = result.index || -1;
+                const index = result.index !== undefined ? result.index : -1;
                 if (index === -1) {
                     continue;
                 }

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -419,7 +419,7 @@ export function findReplacements(document: TextDocument, content: string, value:
         if (result !== null && result.length) {
             const match = result[0];
             if (match) {
-                const index = result.index !== undefined ? result.index : -1;
+                const index = result.index ?? -1;
                 if (index === -1) {
                     continue;
                 }


### PR DESCRIPTION
Hi @meganbradley,

Here is a feature that I believe will be super impactful. It will automatically replace smart quotes in MD files. There is a very common workflow where PMs provide Word docs with content and if authors copy & paste, this leads to MD files being littered with undesirable characters. Here is a quick demo of this feature in action (of course backed by a configuration making it optional).

When `true`, automatically replace smart quotes (`“, ”, ‘, and ’`) such as those found in Word documents - with standard quotes (`" and '`) in markdown files.

![replace-smart-quotes-ez](https://user-images.githubusercontent.com/7679720/75489685-511ca200-5978-11ea-81e5-8e15763f2c43.gif)
