### PR TITLE
Fix formatting in dev lang tooltip heading

### DIFF
--- a/docs-markdown/src/helper/highlight-langs.ts
+++ b/docs-markdown/src/helper/highlight-langs.ts
@@ -304,8 +304,7 @@ function getLanguageIdentifierCompletionItems(range: Range | undefined, isCancel
         if (langs) {
             langs.forEach((lang) => {
                 const langId = lang.aliases[0];
-                const markdownSample = new MarkdownString();
-                markdownSample.appendText("*Output:*");
+                const markdownSample = new MarkdownString("Output:");
                 markdownSample.appendCodeblock("", langId);
 
                 const item = new CompletionItem(lang.language, CompletionItemKind.Value);


### PR DESCRIPTION
Fix the invalid formatting in the tooltip:

![image](https://user-images.githubusercontent.com/10702007/75578963-7669e880-5a2a-11ea-91c8-4bf7251f0a98.png)

With this PR, the "Output:" heading displays as follows:

![image](https://user-images.githubusercontent.com/10702007/75578861-46bae080-5a2a-11ea-8ee0-d295b18285b1.png)
