### PR TITLE
Swap ordering of wording in invalid devlang message

### DIFF
--- a/docs-markdown/src/helper/highlight-langs.ts
+++ b/docs-markdown/src/helper/highlight-langs.ts
@@ -387,7 +387,7 @@ export const markdownCodeActionProvider: CodeActionProvider = {
                         if (!isValidCodeLang(lang)) {
                             const action =
                                 new CodeAction(
-                                    `Click to fix "${lang}" unrecognized code-fence language identifer`,
+                                    `Click to fix unrecognized "${lang}" code-fence language identifer`,
                                     CodeActionKind.QuickFix);
 
                             const indexWithOffset = index + 3; // Account for "```".


### PR DESCRIPTION
Swap the position of 2 words so that the resulting message makes more sense.