### PR TITLE
Expanded the usage of the update metadata values command to YAML

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -196,8 +196,7 @@
       {
         "command": "updateImplicitMetadataValues",
         "title": "Update Implicit Metadata Values",
-        "category": "Docs",
-        "enablement": "resourceLangId == markdown"
+        "category": "Docs"
       },
       {
         "command": "sortSelectionAscending",
@@ -227,8 +226,7 @@
       {
         "command": "updateImplicitMetadataValues",
         "title": "Update Implicit Metadata Values",
-        "category": "Docs",
-        "enablement": "resourceLangId == markdown"
+        "category": "Docs"
       }
     ],
     "menus": {
@@ -242,12 +240,12 @@
       ],
       "editor/context": [
         {
-          "when": "editorTextFocus",
+          "when": "editorTextFocus && resourceLangId == markdown || resourceLangId == yaml",
           "command": "updateMetadataDate",
           "group": "1_modification"
         },
         {
-          "when": "editorTextFocus",
+          "when": "editorTextFocus && resourceLangId == markdown || resourceLangId == yaml",
           "command": "updateImplicitMetadataValues",
           "group": "1_modification"
         },

--- a/docs-markdown/src/controllers/metadata-controller.ts
+++ b/docs-markdown/src/controllers/metadata-controller.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 import { commands, TextEditor, window, workspace } from "vscode";
-import { isMarkdownFileCheck, noActiveEditorMessage, sendTelemetryData, tryFindFile } from "../helper/common";
+import { noActiveEditorMessage, sendTelemetryData, tryFindFile } from "../helper/common";
 import { applyReplacements, findReplacement, Replacements } from "../helper/utility";
 
 export function insertMetadataCommands() {
@@ -84,7 +84,8 @@ export async function updateImplicitMetadataValues() {
         return;
     }
 
-    if (!isMarkdownFileCheck(editor, false)) {
+    if (editor.document.languageId !== "markdown" &&
+        editor.document.languageId !== "yaml") {
         return;
     }
 
@@ -199,7 +200,8 @@ export async function updateMetadataDate() {
         return;
     }
 
-    if (!isMarkdownFileCheck(editor, false)) {
+    if (editor.document.languageId !== "markdown" &&
+        editor.document.languageId !== "yaml") {
         return;
     }
 


### PR DESCRIPTION
I wanted to use some of the update metadata commands now for a while in YAML, as they are the same in terms of replacing matched `RegExp` in the `metadata-controller.ts` logic. This pull request does enables it for YAML now too.