### PR TITLE
Fixed bug with code snippet id.

### DIFF
--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -275,7 +275,7 @@ export function includeBuilder(link: string, title: string) {
 
 export function snippetBuilder(language: string, relativePath: string, id?: string, range?: string) {
     if (id) {
-        return `:::code language="${language}" source="${relativePath}" id=${id}":::`;
+        return `:::code language="${language}" source="${relativePath}" id="${id}":::`;
     } else if (range) {
         return `:::code language="${language}" source="${relativePath}" range="${range}":::`;
     } else {


### PR DESCRIPTION
Issue referenced by #470. Small bug fix to include double quote when user selects Id snippet type.