### PR TITLE
Implemented daisy chain resolution

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -458,10 +458,24 @@
       "type": "object",
       "title": "Docs Markdown Extension Configuration",
       "properties": {
+<<<<<<< HEAD
         "markdown.replaceSmartQuotes": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "When `true`, automatically replace smart quotes (`“, ”, ‘, and ’`) with standard quotes (`\" and '`) in markdown files. This feature extends to other characters as well, i.e.; (`©, ™, ®, •`, subscript and superscript characters). This is useful when pasting text from Word documents."
+=======
+        "markdown.docsetName": {
+          "type": "string",
+          "default": "azure",
+          "markdownDescription": "The name of the docset, most often the route segment immediately following the locale in the URL, (i.e.; https://docs.microsoft.com/en-us/azure/ would be 'azure'). Sometimes this value is specified in the `docfx.json` file under the `build/dest` node.",
+          "scope": "window"
+        },
+        "markdown.docsetRootFolderName": {
+          "type": "string",
+          "default": "articles",
+          "markdownDescription": "The name of the docset root folder. Sometimes this value is specified in the `docfx.json` file under the `build/resource/src` node.",
+          "scope": "window"
+>>>>>>> Initial bits for handling daisy chains in redirects.
         },
         "markdown.allAvailableLanguages": {
           "type": "boolean",

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -44,6 +44,11 @@
         "category": "Docs"
       },
       {
+        "command": "applyRedirectDaisyChainResolution",
+        "title": "Resolve redirection file daisy-chains",
+        "category": "Docs"
+      },
+      {
         "command": "formatBold",
         "title": "Bold",
         "category": "Docs"
@@ -295,6 +300,10 @@
           "group": "Docs"
         },
         {
+          "command": "applyRedirectDaisyChainResolution",
+          "group": "Docs"
+        },
+        {
           "command": "formatBold",
           "group": "Docs",
           "when": "resourceLangId == markdown"
@@ -458,12 +467,11 @@
       "type": "object",
       "title": "Docs Markdown Extension Configuration",
       "properties": {
-<<<<<<< HEAD
         "markdown.replaceSmartQuotes": {
           "type": "boolean",
           "default": true,
           "markdownDescription": "When `true`, automatically replace smart quotes (`“, ”, ‘, and ’`) with standard quotes (`\" and '`) in markdown files. This feature extends to other characters as well, i.e.; (`©, ™, ®, •`, subscript and superscript characters). This is useful when pasting text from Word documents."
-=======
+        },
         "markdown.docsetName": {
           "type": "string",
           "default": "azure",
@@ -475,7 +483,6 @@
           "default": "articles",
           "markdownDescription": "The name of the docset root folder. Sometimes this value is specified in the `docfx.json` file under the `build/resource/src` node.",
           "scope": "window"
->>>>>>> Initial bits for handling daisy chains in redirects.
         },
         "markdown.allAvailableLanguages": {
           "type": "boolean",

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -465,7 +465,7 @@
     },
     "configuration": {
       "type": "object",
-      "title": "Docs Markdown Extension Configuration",
+      "title": "Docs Markdown",
       "properties": {
         "markdown.replaceSmartQuotes": {
           "type": "boolean",
@@ -493,7 +493,7 @@
         "markdown.allAvailableLanguages": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Provide all available languages when suggesting code-fence language identifiers. Overrides `markdown.docsetLanguages` setting."
+          "markdownDescription": "Provide all available languages when suggesting code-fence language identifiers. Overrides [Markdown: Docset Languages](#markdown.docsetLanguages) setting."
         },
         "markdown.docsetLanguages": {
           "type": [
@@ -501,7 +501,7 @@
             "null"
           ],
           "title": "Language Identifiers",
-          "markdownDescription": "When the \"All Available Languages\" (`markdown.allAvailableLanguages`) flag is set to `false`, the suggested completion list displayed when typing an opening code-block (` ``` `) is filtered to the provided language identifiers.",
+          "markdownDescription": "When the [Markdown: All Available Languages](#markdown.allAvailableLanguages) flag is set to `false`, the suggested completion list displayed when typing an opening code-block (` ``` `) is filtered to the provided language identifiers.",
           "items": {
             "type": "string",
             "enum": [

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -474,13 +474,13 @@
         },
         "markdown.docsetName": {
           "type": "string",
-          "default": "azure",
+          "default": "< Not set >",
           "markdownDescription": "The name of the docset, most often the route segment immediately following the locale in the URL, (i.e.; https://docs.microsoft.com/en-us/azure/ would be 'azure'). Sometimes this value is specified in the `docfx.json` file under the `build/dest` node.",
           "scope": "window"
         },
         "markdown.docsetRootFolderName": {
           "type": "string",
-          "default": "articles",
+          "default": "< Not set >",
           "markdownDescription": "The name of the docset root folder. Sometimes this value is specified in the `docfx.json` file under the `build/resource/src` node.",
           "scope": "window"
         },

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
   "description": "Docs Markdown Extension",
   "icon": "images/docs-logo-ms.png",
   "aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-  "version": "0.2.60",
+  "version": "0.2.61",
   "publisher": "docsmsft",
   "homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
   "bugs": {

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -484,6 +484,12 @@
           "markdownDescription": "The name of the docset root folder. Sometimes this value is specified in the `docfx.json` file under the `build/resource/src` node.",
           "scope": "window"
         },
+        "markdown.omitDefaultJsonProperties": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "When `true` omits default JSON values when serializing objects, i.e.; the `.openpublishing.redirection.json` file would have the `redirect_document_id` properties omitted when they are `false`.",
+          "scope": "window"
+        },
         "markdown.allAvailableLanguages": {
           "type": "boolean",
           "default": false,

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -474,13 +474,13 @@
         },
         "markdown.docsetName": {
           "type": "string",
-          "default": "< Not set >",
+          "default": "",
           "markdownDescription": "The name of the docset, most often the route segment immediately following the locale in the URL, (i.e.; https://docs.microsoft.com/en-us/azure/ would be 'azure'). Sometimes this value is specified in the `docfx.json` file under the `build/dest` node.",
           "scope": "window"
         },
         "markdown.docsetRootFolderName": {
           "type": "string",
-          "default": "< Not set >",
+          "default": "",
           "markdownDescription": "The name of the docset root folder. Sometimes this value is specified in the `docfx.json` file under the `build/resource/src` node.",
           "scope": "window"
         },

--- a/docs-markdown/src/controllers/master-redirect-controller.ts
+++ b/docs-markdown/src/controllers/master-redirect-controller.ts
@@ -204,7 +204,7 @@ async function applyRedirectDaisyChainResolution() {
                 new Position(lineCount, lastLine.range.end.character));
 
         await editor.edit((builder) => {
-            builder.replace(entireDocSelection, JSON.stringify(redirects, replacer, 4));
+            builder.replace(entireDocSelection, JSON.stringify(redirects, replacer, 2));
         });
 
         await editor.document.save();

--- a/docs-markdown/src/controllers/master-redirect-controller.ts
+++ b/docs-markdown/src/controllers/master-redirect-controller.ts
@@ -147,6 +147,17 @@ async function applyRedirectDaisyChainResolution() {
 
     const file = tryFindFile(folder.uri.fsPath, redirectFileName);
     if (!!file && fs.existsSync(file)) {
+        if (!editor.document.uri.fsPath.endsWith(redirectFileName)) {
+            const openFile = await window.showErrorMessage(
+                `Unable to update the master redirects, please open the "${redirectFileName}" file then try again!`,
+                "Open File");
+            if (!!openFile) {
+                const document = await workspace.openTextDocument(file);
+                await window.showTextDocument(document);
+            }
+            return;
+        }
+
         const jsonBuffer = fs.readFileSync(file);
         redirects = JSON.parse(jsonBuffer.toString()) as IMasterRedirections;
     }

--- a/docs-markdown/src/controllers/master-redirect-controller.ts
+++ b/docs-markdown/src/controllers/master-redirect-controller.ts
@@ -280,7 +280,12 @@ function redirectsToJson(redirects: IMasterRedirections | null, config: Workspac
             : value;
     };
 
-    return JSON.stringify(redirects, replacer, 2);
+    const space =
+        workspace.getConfiguration("editor").insertSpaces
+            ? workspace.getConfiguration("editor").tabSize as number || 2
+            : 2;
+
+    return JSON.stringify(redirects, replacer, space);
 }
 
 export async function sortMasterRedirectionFile() {

--- a/docs-markdown/src/controllers/master-redirect-controller.ts
+++ b/docs-markdown/src/controllers/master-redirect-controller.ts
@@ -224,6 +224,14 @@ async function applyRedirectDaisyChainResolution() {
                     ? targetRedirectUrl
                     : source.redirect!.adaptHashAndQueryString(targetRedirectUrl);
             source.redirection.redirect_url = newRedirectUrl;
+
+            if (source.redirection.redirect_document_id) {
+                if (isExternalUrl ||
+                    !newRedirectUrl.startsWith(`/${options.docsetName}/`)) {
+                    source.redirection.redirect_document_id = false;
+                }
+            }
+
             resolvedDaisyChains = true;
         }
     });

--- a/docs-markdown/src/controllers/master-redirect-controller.ts
+++ b/docs-markdown/src/controllers/master-redirect-controller.ts
@@ -157,6 +157,8 @@ async function applyRedirectDaisyChainResolution() {
             : null;
     };
 
+    let daisyChainsResolved = 0;
+    let maxDepthResolved = 0;
     let resolvedDaisyChains = false;
     redirectsLookup.forEach((source, _) => {
         const { url, redirect } = source;
@@ -168,14 +170,20 @@ async function applyRedirectDaisyChainResolution() {
 
         let daisyChainPath = null;
         let targetRedirectUrl = null;
+        let depthResolved = 0;
         let targetRedirect = findRedirect(redirectFilePath);
         while (targetRedirect !== null) {
+            depthResolved++;
+            if (depthResolved > maxDepthResolved) {
+                maxDepthResolved = depthResolved;
+            }
             targetRedirectUrl = targetRedirect!.url!.toUrl();
             daisyChainPath = targetRedirect!.url!.filePath;
             targetRedirect = findRedirect(daisyChainPath);
         }
 
         if (targetRedirectUrl && targetRedirectUrl !== source.redirect.redirect_url) {
+            daisyChainsResolved++;
             source.redirect.redirect_url = targetRedirectUrl;
             resolvedDaisyChains = true;
         }
@@ -183,6 +191,8 @@ async function applyRedirectDaisyChainResolution() {
 
     if (resolvedDaisyChains) {
         await updateRedirects(editor, redirects, config);
+        const numberFormat = Intl.NumberFormat();
+        showStatusMessage(`Resolved ${numberFormat.format(daisyChainsResolved)} daisy chains, at a max-depth of ${maxDepthResolved}!`);
     }
 }
 

--- a/docs-markdown/src/controllers/master-redirect-controller.ts
+++ b/docs-markdown/src/controllers/master-redirect-controller.ts
@@ -113,6 +113,17 @@ export class RedirectUrl {
         const withoutExtension = this.filePath.replace(".md", "");
         return `/${withoutExtension.replace(this.config.docsetRootFolderName, this.config.docsetName)}`;
     }
+
+    public adaptHashAndQueryString(redirectUrl: string): string {
+        let resultingRedirectUrl = redirectUrl;
+        if (this.url.search) {
+            resultingRedirectUrl += this.url.search;
+        }
+        if (this.url.hash) {
+            resultingRedirectUrl += this.url.hash;
+        }
+        return resultingRedirectUrl;
+    }
 }
 
 async function applyRedirectDaisyChainResolution() {
@@ -184,7 +195,8 @@ async function applyRedirectDaisyChainResolution() {
 
         if (targetRedirectUrl && targetRedirectUrl !== source.redirect.redirect_url) {
             daisyChainsResolved++;
-            source.redirect.redirect_url = targetRedirectUrl;
+            const newRedirectUrl = source.url!.adaptHashAndQueryString(targetRedirectUrl);
+            source.redirect.redirect_url = newRedirectUrl;
             resolvedDaisyChains = true;
         }
     });

--- a/docs-markdown/src/controllers/master-redirect-controller.ts
+++ b/docs-markdown/src/controllers/master-redirect-controller.ts
@@ -171,9 +171,8 @@ async function applyRedirectDaisyChainResolution() {
         docsetName: config.docsetName,
         docsetRootFolderName: config.docsetRootFolderName,
     };
-    const notSet = "< Not set >";
-    if (options.docsetName === notSet ||
-        options.docsetRootFolderName === notSet) {
+    if (options.docsetName === "" ||
+        options.docsetRootFolderName === "") {
         // Open the settings, and prompt the user to enter values.
         await commands.executeCommand("workbench.action.openSettings", "@ext:docsmsft.docs-markdown");
         postWarning("Please set the Docset Name and Docset Root Folder Name before using this command.");
@@ -251,6 +250,8 @@ async function applyRedirectDaisyChainResolution() {
         await updateRedirects(editor, redirects, config);
         const numberFormat = Intl.NumberFormat();
         showStatusMessage(`Resolved ${numberFormat.format(daisyChainsResolved)} daisy chains, at a max-depth of ${maxDepthResolved}!`);
+    } else {
+        showStatusMessage("There are no daisy chains found.");
     }
 }
 

--- a/docs-markdown/src/test/suite/controllers/master-redirect-controller.test.ts
+++ b/docs-markdown/src/test/suite/controllers/master-redirect-controller.test.ts
@@ -1,0 +1,48 @@
+import * as chai from "chai";
+import * as spies from "chai-spies";
+import { RedirectUrl } from "../../../controllers/master-redirect-controller";
+
+chai.use(spies);
+
+const expect = chai.expect;
+
+suite("Master Redirect Controller", () => {
+    const options = {
+        docsetName: "azure",
+        docsetRootFolderName: "articles",
+    };
+
+    test("RedirectUrl parse fully qualified URL", () => {
+        const url = "https://docs.microsoft.com/azure/subject/file";
+        const redirectUrl = RedirectUrl.parse(options, url);
+
+        expect(redirectUrl!.filePath).to.equal("articles/subject/file.md");
+        expect(redirectUrl!.toUrl()).to.equal("/azure/subject/file");
+    });
+
+    test("RedirectUrl parse relative standard path", () => {
+        const url = "/azure/subject/file";
+        const redirectUrl = RedirectUrl.parse(options, url);
+
+        expect(redirectUrl!.filePath).to.equal("articles/subject/file.md");
+        expect(redirectUrl!.toUrl()).to.equal(url);
+    });
+
+    test("RedirectUrl parse handles hash tag", () => {
+        const url = "https://docs.microsoft.com/azure/subject/file#bookmark";
+        const redirectUrl = RedirectUrl.parse(options, url);
+
+        expect(redirectUrl!.filePath).to.equal("articles/subject/file.md");
+        expect(redirectUrl!.toUrl()).to.equal("/azure/subject/file");
+        expect(redirectUrl!.url.hash).to.equal("#bookmark");
+    });
+
+    test("RedirectUrl parse handles query strings", () => {
+        const url = "https://docs.microsoft.com/azure/subject/file?pivot=lang-csharp";
+        const redirectUrl = RedirectUrl.parse(options, url);
+
+        expect(redirectUrl!.filePath).to.equal("articles/subject/file.md");
+        expect(redirectUrl!.toUrl()).to.equal("/azure/subject/file");
+        expect(redirectUrl!.url.search).to.equal("?pivot=lang-csharp");
+    });
+});

--- a/docs-markdown/src/test/suite/controllers/master-redirect-controller.test.ts
+++ b/docs-markdown/src/test/suite/controllers/master-redirect-controller.test.ts
@@ -45,4 +45,32 @@ suite("Master Redirect Controller", () => {
         expect(redirectUrl!.toUrl()).to.equal("/azure/subject/file");
         expect(redirectUrl!.url.search).to.equal("?pivot=lang-csharp");
     });
+
+    test("RedirectUrl adaptHashAndQueryString correctly maintains query", () => {
+        const url = "https://docs.microsoft.com/azure/subject/file?pivot=lang-csharp";
+        const redirectUrl = RedirectUrl.parse(options, url);
+
+        expect(redirectUrl!.adaptHashAndQueryString("/azure/file")).to.equal("/azure/file?pivot=lang-csharp");
+    });
+
+    test("RedirectUrl adaptHashAndQueryString correctly maintains hash", () => {
+        const url = "https://docs.microsoft.com/azure/subject/file#bookmark";
+        const redirectUrl = RedirectUrl.parse(options, url);
+
+        expect(redirectUrl!.adaptHashAndQueryString("/azure/file")).to.equal("/azure/file#bookmark");
+    });
+
+    test("RedirectUrl isExternalUrl returns false", () => {
+        const url = "https://docs.microsoft.com/azure/subject/file";
+        const redirectUrl = RedirectUrl.parse(options, url);
+
+        expect(redirectUrl!.isExternalUrl).to.be.equal(false);
+    });
+
+    test("RedirectUrl isExternalUrl returns true", () => {
+        const url = "https://github.com/azure-docs";
+        const redirectUrl = RedirectUrl.parse(options, url);
+
+        expect(redirectUrl!.isExternalUrl).to.be.equal(true);
+    });
 });


### PR DESCRIPTION
This pull request adds the ability for daisy chains to be resolved in the *.openpublishing.redirection.json* file automatically. This details of this feature were initially discussed here as [considerations](https://docs.microsoft.com/en-us/contribute/docs-authoring/sort-redirects#considerations).

![redirect-resolution](https://user-images.githubusercontent.com/7679720/77361023-7c4aa500-6d1c-11ea-83cc-6999fad3174b.gif)

## Example

Below is a before and after scenario, to demonstrate the goal of this functionality.

### Before

```json
{
    "redirections": [
        {
            "source_path": "articles/subject/a.md",
            "redirect_url": "/azure/subject/b",
            "redirect_document_id": false
        },
        {
            "source_path": "articles/subject/b.md",
            "redirect_url": "/azure/subject/c?query-string#bookmark",
            "redirect_document_id": false
        },
        {
            "source_path": "articles/subject/c.md",
            "redirect_url": "/azure/subject/d?pivot=example",
            "redirect_document_id": true
        },
        {
            "source_path": "articles/subject/z.md",
            "redirect_url": "https://docs.microsoft.com/azure/subject/b",
            "redirect_document_id": false
        }
    ]
}
```

### After

```json
{
    "redirections": [
        {
            "source_path": "articles/subject/a.md",
            "redirect_url": "/azure/subject/d"
        },
        {
            "source_path": "articles/subject/b.md",
            "redirect_url": "/azure/subject/d"
        },
        {
            "source_path": "articles/subject/c.md",
            "redirect_url": "/azure/subject/d?pivot=example",
            "redirect_document_id": true
        },
        {
            "source_path": "articles/subject/z.md",
            "redirect_url": "/azure/subject/d"
        }
    ]
}
```

If the user initiates this command with a file other than the *.openpublishing.redirection.json* file, they'll see an error like this:

![image](https://user-images.githubusercontent.com/7679720/77539591-a5c81580-6e6f-11ea-9242-0246a9b0c50c.png)

Additionally, there are settings that need to be specified. The **Docset Name** and **Docset Root Folder Name** are required in order for the tool to understand the route segments in the URLs.

![image](https://user-images.githubusercontent.com/7679720/77539767-e4f66680-6e6f-11ea-9144-4b737dda3c84.png)



