### PR TITLE
TSLint fixes

### DIFF
--- a/docs-markdown/package-lock.json
+++ b/docs-markdown/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "docs-markdown",
-  "version": "0.2.60",
+  "version": "0.2.61",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/docs-markdown/src/controllers/bold-controller.ts
+++ b/docs-markdown/src/controllers/bold-controller.ts
@@ -1,11 +1,10 @@
 "use strict";
 
-import { window, Selection, Range, TextEditorEdit } from "vscode";
+import { Range, Selection, TextEditorEdit, window } from "vscode";
 import { insertContentToEditor, isMarkdownFileCheck, noActiveEditorMessage, postWarning, showStatusMessage } from "../helper/common";
-import { sendTelemetryData } from "../helper/telemetry";
 import { insertUnselectedText } from "../helper/format-logic-manager";
 import { isBold, isBoldAndItalic } from "../helper/format-styles";
-import { reporter } from "../helper/telemetry";
+import { reporter, sendTelemetryData } from "../helper/telemetry";
 
 const telemetryCommand: string = "formatBold";
 
@@ -30,11 +29,11 @@ export function formatBold() {
             return;
         }
 
-        let selections: Selection[] = editor.selections;
+        const selections: Selection[] = editor.selections;
         let range;
 
         // if unselect text, add bold syntax without any text
-        if (selections.length == 0) {
+        if (selections.length === 0) {
             const cursorPosition = editor.selection.active;
             const selectedText = "";
             // assumes the range of bold syntax
@@ -47,7 +46,7 @@ export function formatBold() {
         }
 
         // if only a selection is made with a single cursor
-        if (selections.length == 1) {
+        if (selections.length === 1) {
             const selection = editor.selection;
             const selectedText = editor.document.getText(selection);
             const cursorPosition = editor.selection.active;
@@ -61,21 +60,21 @@ export function formatBold() {
 
         // if mulitple cursors were used to make selections
         if (selections.length > 1) {
-            editor.edit(function (edit: TextEditorEdit): void {
+            editor.edit((edit: TextEditorEdit): void => {
                 selections.forEach((selection: Selection) => {
                     for (let i = selection.start.line; i <= selection.end.line; i++) {
-                        let selectedText = editor.document.getText(selection);
-                        let formattedText = bold(selectedText);
+                        const selectedText = editor.document.getText(selection);
+                        const formattedText = bold(selectedText);
                         edit.replace(selection, formattedText);
                     }
                 });
-            }).then(success => {
+            }).then((success) => {
                 if (!success) {
                     postWarning("Could not format selections. Abandoning command.");
                     showStatusMessage("Could not format selections. Abandoning command.");
                     return;
                 }
-            })
+            });
         }
     }
     sendTelemetryData(telemetryCommand, "");

--- a/docs-markdown/src/controllers/bookmark-controller.ts
+++ b/docs-markdown/src/controllers/bookmark-controller.ts
@@ -52,15 +52,15 @@ export function insertBookmarkExternal() {
     }
 
     // recursively get all the files from the root folder
-    files(folderPath, (err: any, files: any) => {
+    files(folderPath, (err: any, mdFiles: any) => {
         if (err) {
             window.showErrorMessage(err);
             throw err;
         }
 
         const items: QuickPickItem[] = [];
-        files.sort();
-        files.filter((file: any) => markdownExtensionFilter.indexOf(extname(file.toLowerCase())) !== -1).forEach((file: any) => {
+        mdFiles.sort();
+        mdFiles.filter((file: any) => markdownExtensionFilter.indexOf(extname(file.toLowerCase())) !== -1).forEach((file: any) => {
             items.push({ label: basename(file), description: dirname(file) });
         });
 

--- a/docs-markdown/src/controllers/code-controller.ts
+++ b/docs-markdown/src/controllers/code-controller.ts
@@ -2,10 +2,10 @@
 
 import { QuickPickOptions, Range, Selection, TextEditorEdit, window } from "vscode";
 import { insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage, postWarning, showStatusMessage } from "../helper/common";
-import { sendTelemetryData } from "../helper/telemetry";
 import { insertUnselectedText } from "../helper/format-logic-manager";
 import { isInlineCode, isMultiLineCode } from "../helper/format-styles";
 import { getLanguageIdentifierQuickPickItems, languages } from "../helper/highlight-langs";
+import { sendTelemetryData } from "../helper/telemetry";
 
 const telemetryCommand: string = "formatCode";
 

--- a/docs-markdown/src/controllers/include-controller.ts
+++ b/docs-markdown/src/controllers/include-controller.ts
@@ -5,8 +5,8 @@ import * as os from "os";
 import * as path from "path";
 import { QuickPickItem, window, workspace } from "vscode";
 import { hasValidWorkSpaceRootPath, isMarkdownFileCheck, noActiveEditorMessage } from "../helper/common";
-import { includeBuilder } from "../helper/utility";
 import { sendTelemetryData } from "../helper/telemetry";
+import { includeBuilder } from "../helper/utility";
 
 const telemetryCommand: string = "insertInclude";
 const markdownExtension = ".md";

--- a/docs-markdown/src/controllers/italic-controller.ts
+++ b/docs-markdown/src/controllers/italic-controller.ts
@@ -1,10 +1,10 @@
 "use strict";
 
-import { window, Selection, Range, TextEditorEdit } from "vscode";
+import { Range, Selection, TextEditorEdit, window } from "vscode";
 import { insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage, postWarning, showStatusMessage } from "../helper/common";
-import { sendTelemetryData } from "../helper/telemetry";
 import { insertUnselectedText } from "../helper/format-logic-manager";
 import { isBoldAndItalic, isItalic } from "../helper/format-styles";
+import { sendTelemetryData } from "../helper/telemetry";
 
 const telemetryCommand: string = "formatItalic";
 
@@ -34,11 +34,11 @@ export function formatItalic() {
 
         // const selection = editor.selection;
         // const selectedText = editor.document.getText(selection);
-        let selections: Selection[] = editor.selections;
+        const selections: Selection[] = editor.selections;
         let range;
 
         // if unselect text, add italic syntax without any text
-        if (selections.length == 0) {
+        if (selections.length === 0) {
             const cursorPosition = editor.selection.active;
             const selectedText = "";
 
@@ -53,7 +53,7 @@ export function formatItalic() {
         }
 
         // if only a selection is made with a single cursor
-        if (selections.length == 1) {
+        if (selections.length === 1) {
             const selection = editor.selection;
             const selectedText = editor.document.getText(selection);
             const cursorPosition = editor.selection.active;
@@ -68,21 +68,21 @@ export function formatItalic() {
 
         // if mulitple cursors were used to make selections
         if (selections.length > 1) {
-            editor.edit(function (edit: TextEditorEdit): void {
+            editor.edit((edit: TextEditorEdit): void => {
                 selections.forEach((selection: Selection) => {
                     for (let i = selection.start.line; i <= selection.end.line; i++) {
-                        let selectedText = editor.document.getText(selection);
-                        let formattedText = italicize(selectedText);
+                        const selectedText = editor.document.getText(selection);
+                        const formattedText = italicize(selectedText);
                         edit.replace(selection, formattedText);
                     }
                 });
-            }).then(success => {
+            }).then((success) => {
                 if (!success) {
                     postWarning("Could not format selections. Abandoning command.");
                     showStatusMessage("Could not format selections. Abandoning command.");
                     return;
                 }
-            })
+            });
         }
     }
     sendTelemetryData(telemetryCommand, "");

--- a/docs-markdown/src/controllers/list-controller.ts
+++ b/docs-markdown/src/controllers/list-controller.ts
@@ -3,9 +3,9 @@
 import * as vscode from "vscode";
 import { ListType } from "../constants/list-type";
 import { insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage } from "../helper/common";
-import { sendTelemetryData } from "../helper/telemetry";
 import { addIndent, autolistAlpha, autolistNumbered, checkEmptyLine, checkEmptySelection, CountIndent, createBulletedListFromText, createNumberedListFromText, fixedBulletedListRegex, fixedNumberedListWithIndentRegexTemplate, getAlphabetLine, getNumberedLine, getNumberedLineWithRegex, insertList, isBulletedLine, nestedNumberedList, removeNestedListMultipleLine, removeNestedListSingleLine, tabPattern } from "../helper/list";
 import { output } from "../helper/output";
+import { sendTelemetryData } from "../helper/telemetry";
 
 const telemetryCommand: string = "insertList";
 let commandOption: string;

--- a/docs-markdown/src/controllers/master-redirect-controller.ts
+++ b/docs-markdown/src/controllers/master-redirect-controller.ts
@@ -5,7 +5,7 @@ import * as dir from "node-dir";
 import { homedir } from "os";
 import { basename, extname, join, relative } from "path";
 import { URL } from "url";
-import { Position, Selection, TextEditor, Uri, window, workspace, WorkspaceConfiguration, WorkspaceFolder, commands } from "vscode";
+import { commands, Position, Selection, TextEditor, Uri, window, workspace, WorkspaceConfiguration, WorkspaceFolder } from "vscode";
 import * as YAML from "yamljs";
 import { generateTimestamp, naturalLanguageCompare, postError, postWarning, tryFindFile } from "../helper/common";
 import { output } from "../helper/output";
@@ -471,9 +471,9 @@ export function generateMasterRedirectionFile(rootPath?: string, resolve?: any) 
 
                             source.pipe(dest);
                             source.on("close", () => {
-                                fs.unlink(item.fileFullPath, (err) => {
+                                fs.unlink(item.fileFullPath, (error) => {
                                     if (err) {
-                                        postError(`Error: ${err}`);
+                                        postError(`Error: ${error}`);
                                     }
                                 });
                             });

--- a/docs-markdown/src/controllers/media-controller.ts
+++ b/docs-markdown/src/controllers/media-controller.ts
@@ -49,11 +49,11 @@ export function insertVideo() {
                 || urlLowerCase.startsWith("https://www.youtube.com/embed")
                 || urlLowerCase.startsWith("https://www.microsoft.com/en-us/videoplayer/embed")
                 ? ""
-                : "https://channel9.msdn.com, https://www.youtube.com/embed or https://www.microsoft.com/en-us/videoplayer/embed are required prefixes for video URLs. Link will not be added if prefix is not present."
+                : "https://channel9.msdn.com, https://www.youtube.com/embed or https://www.microsoft.com/en-us/videoplayer/embed are required prefixes for video URLs. Link will not be added if prefix is not present.";
         };
         vscode.window.showInputBox({
             placeHolder: "Enter URL; Begin typing to see the allowed video URL prefixes.",
-            validateInput: validateInput
+            validateInput,
         }).then((val) => {
             // If the user adds a link that doesn't include the http(s) protocol, show a warning and don't add the link.
             if (val === undefined) {

--- a/docs-markdown/src/controllers/media-controller.ts
+++ b/docs-markdown/src/controllers/media-controller.ts
@@ -53,7 +53,7 @@ export function insertVideo() {
         };
         vscode.window.showInputBox({
             placeHolder: "Enter URL; Begin typing to see the allowed video URL prefixes.",
-            validateInput,
+            validateInput: validateInput
         }).then((val) => {
             // If the user adds a link that doesn't include the http(s) protocol, show a warning and don't add the link.
             if (val === undefined) {

--- a/docs-markdown/src/controllers/no-loc-controller.ts
+++ b/docs-markdown/src/controllers/no-loc-controller.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { Position, Range, Selection, TextEditor, window, CompletionItem } from "vscode";
+import { CompletionItem, Position, Range, Selection, TextEditor, window } from "vscode";
 import { insertContentToEditor, isMarkdownFileCheck, noActiveEditorMessage } from "../helper/common";
 import { sendTelemetryData } from "../helper/telemetry";
 import { isCursorInsideYamlHeader } from "../helper/yaml-metadata";
@@ -24,7 +24,6 @@ export function noLocCompletionItemsMarkdown() {
 export function noLocCompletionItemsYaml() {
     return [new CompletionItem(`no-loc:\n- `)];
 }
-
 
 /**
  * Inserts non-localizable text
@@ -50,7 +49,7 @@ export function noLocText() {
 }
 
 function insertYamlNoLocEntry(editor: TextEditor) {
-    commandOption = "yaml-entry"
+    commandOption = "yaml-entry";
     sendTelemetryData(telemetryCommand, commandOption);
     if (isContentOnCurrentLine(editor)) {
         window.showErrorMessage("The no-loc metadata must be inserted on a new line.");
@@ -83,7 +82,7 @@ function getTabInsertion(editor: TextEditor): string {
 }
 
 function insertMarkdownNoLocEntry(editor: TextEditor) {
-    commandOption = "markdown-entry"
+    commandOption = "markdown-entry";
     sendTelemetryData(telemetryCommand, commandOption);
     const textSelection = editor.document.getText(editor.selection);
     if (textSelection === "") {

--- a/docs-markdown/src/controllers/quick-pick-menu-controller.ts
+++ b/docs-markdown/src/controllers/quick-pick-menu-controller.ts
@@ -2,6 +2,7 @@
 
 import * as vscode from "vscode";
 import { checkExtension, generateTimestamp } from "../helper/common";
+import { output } from "../helper/output";
 import { insertAlert } from "./alert-controller";
 import { formatBold } from "./bold-controller";
 import { applyCleanup } from "./cleanup/cleanup-controller";
@@ -9,8 +10,9 @@ import { formatCode } from "./code-controller";
 import { pickImageType } from "./image-controller";
 import { insertInclude } from "./include-controller";
 import { formatItalic } from "./italic-controller";
+import { pickLinkType } from "./link-controller";
 import { insertBulletedList, insertNumberedList } from "./list-controller";
-import { insertVideo, insertLink } from "./media-controller";
+import { insertLink, insertVideo } from "./media-controller";
 import { noLocText } from "./no-loc-controller";
 import { previewTopic } from "./preview-controller";
 import { insertRowsAndColumns } from "./row-columns-controller";
@@ -19,8 +21,6 @@ import { insertTable } from "./table-controller";
 import { applyTemplate } from "./template-controller";
 import { applyXref } from "./xref-controller";
 import { insertExpandableParentNode, insertTocEntry, insertTocEntryWithOptions } from "./yaml-controller";
-import { pickLinkType } from "./link-controller";
-import { output } from "../helper/output";
 
 export function quickPickMenuCommand() {
     const commands = [
@@ -113,7 +113,8 @@ export function markdownQuickPick() {
     //    label: "$(tasklist) Cleanup...",
     // }
     const previewSetting = vscode.workspace.getConfiguration("markdown").previewFeatures;
-    if (previewSetting == true) {
+    if (previewSetting === true) {
+        output.appendLine("Preview features will be enabled.");
     }
 
     if (checkExtension("docsmsft.docs-article-templates")) {

--- a/docs-markdown/src/controllers/row-columns-controller.ts
+++ b/docs-markdown/src/controllers/row-columns-controller.ts
@@ -2,8 +2,8 @@
 
 import { window } from "vscode";
 import { isMarkdownFileCheck, noActiveEditorMessage } from "../helper/common";
-import { sendTelemetryData } from "../helper/telemetry";
 import { addNewColumn, addNewColumnWithSpan, createRow } from "../helper/rows-columns";
+import { sendTelemetryData } from "../helper/telemetry";
 
 const rowWithColumns = "Two-column structure";
 const newColumn = "New column";
@@ -32,7 +32,7 @@ export function insertRowsAndColumns() {
         const commandOptions = [
             rowWithColumns,
             newColumn,
-            newColumnWithSpan
+            newColumnWithSpan,
         ];
         window.showQuickPick(commandOptions).then((qpSelection) => {
             if (!qpSelection) {
@@ -70,4 +70,3 @@ export function insertNewColumnWithSpan() {
     commandOption = "column-with-span";
     sendTelemetryData(telemetryCommand, commandOption);
 }
-

--- a/docs-markdown/src/controllers/table-controller.ts
+++ b/docs-markdown/src/controllers/table-controller.ts
@@ -2,10 +2,10 @@
 
 import * as vscode from "vscode";
 import { insertContentToEditor, isMarkdownFileCheck, isValidEditor, noActiveEditorMessage, postWarning } from "../helper/common";
-import { sendTelemetryData } from "../helper/telemetry";
 import { FormatOptions, MarkdownTable } from "../helper/markdown-table";
-import { tableBuilder, validateTableRowAndColumnCount } from "../helper/utility";
 import { output } from "../helper/output";
+import { sendTelemetryData } from "../helper/telemetry";
+import { tableBuilder, validateTableRowAndColumnCount } from "../helper/utility";
 
 const telemetryCommand: string = "insertTable";
 let commandOption: string;
@@ -71,8 +71,8 @@ export function insertTable() {
 
             /// check valid value and exceed 4*4
             if (validateTableRowAndColumnCount(size.length, size[0], size[1])) {
-                const col = Number.parseInt(size[0]);
-                const row = Number.parseInt(size[1]);
+                const col = Number.parseInt(size[0], undefined);
+                const row = Number.parseInt(size[1], undefined);
                 const str = tableBuilder(col, row);
                 insertContentToEditor(editor, insertTable.name, str);
                 logTableMessage = col + ":" + row;

--- a/docs-markdown/src/controllers/xref-controller.ts
+++ b/docs-markdown/src/controllers/xref-controller.ts
@@ -2,9 +2,8 @@
 
 import { CompletionItem, Position, QuickPickItem, Range, window } from "vscode";
 import { insertContentToEditor, isMarkdownFileCheck, noActiveEditorMessage, setCursorPosition } from "../helper/common";
-import { sendTelemetryData } from "../helper/telemetry";
 import { getAsync } from "../helper/http-helper";
-import { reporter } from "../helper/telemetry";
+import { reporter, sendTelemetryData } from "../helper/telemetry";
 
 const telemetryCommand: string = "applyXref";
 const rootUrl: string = "https://xref.docs.microsoft.com";

--- a/docs-markdown/src/controllers/yaml-controller.ts
+++ b/docs-markdown/src/controllers/yaml-controller.ts
@@ -115,7 +115,7 @@ export function createEntry(name: string, href: string, options: boolean) {
   if (cursorPosition === 0 && !options) {
     const tocEntryLineStart =
       `- name: ${name}
-  href: ${href}`
+  href: ${href}`;
     insertContentToEditor(editor, insertTocEntry.name, tocEntryLineStart);
   }
 
@@ -123,7 +123,7 @@ export function createEntry(name: string, href: string, options: boolean) {
     const currentPosition = editor.selection.active.character;
     const tocEntryIndented =
       `- name: ${name}
-  ${attributeSpace.repeat(currentPosition)}href: ${href}`
+  ${attributeSpace.repeat(currentPosition)}href: ${href}`;
     insertContentToEditor(editor, insertTocEntry.name, tocEntryIndented);
   }
 
@@ -407,7 +407,7 @@ export function createParentNode() {
     const parentNodeLineStart = `- name:
   items:
   - name:
-    href:`
+    href:`;
     insertContentToEditor(editor, insertTocEntry.name, parentNodeLineStart);
   }
 
@@ -416,7 +416,7 @@ export function createParentNode() {
       `- name:
     ${attributeSpace.repeat(cursorPosition - 2)}items:
     ${attributeSpace.repeat(cursorPosition - 2)}- name:
-    ${attributeSpace.repeat(cursorPosition)}href:`
+    ${attributeSpace.repeat(cursorPosition)}href:`;
     insertContentToEditor(editor, insertTocEntry.name, parentNodeLineStart);
   }
 


### PR DESCRIPTION
**Updates made to address the following rules**:
- ordered-imports           Named imports must be alphabetized.
- ordered-imports           Import sources within a group must be alphabetized.
- prefer-const              Identifier 'selections' is never reassigned; use 'const' instead of 'let'.
- triple-equals             == should be ===
- only-arrow-functions      non-arrow functions are forbidden
- no-shadowed-variable      Shadowed name: 'files'
- comment-format            comment must start with a space
- no-empty                  block is empty
- radix                     Missing radix parameter

**Affected controllers**:
- Bold
- Bookmark
- Code
- Include
- Italic
- List
- Master-redirect
- Media
- No-loc
- Quick-pick
- Row-column
- Table
- Xref
- Yaml
