### PR TITLE
Docs-linting TSLint fixes

### DIFF
--- a/docs-linting/src/controllers/lint-config-controller.ts
+++ b/docs-linting/src/controllers/lint-config-controller.ts
@@ -12,13 +12,13 @@ export function addFrontMatterTitle() {
     // preserve existing markdownlint.config settings if they exist
     if (markdownlintData.globalValue && addFrontMatterTitleSetting) {
         const existingUserSettings = markdownlintData.globalValue;
-        Object.assign(existingUserSettings, { MD025: { "front_matter_title": "" } });
+        Object.assign(existingUserSettings, { MD025: { front_matter_title: "" } });
         workspace.getConfiguration().update(markdownlintProperty, existingUserSettings, ConfigurationTarget.Global);
         showStatusMessage(`Added front_matter_title property to Markdownlint config setting.`);
     }
     // add md025 property and front_matter_title property directly (no existing settings)
     if (!markdownlintData.globalValue && addFrontMatterTitleSetting) {
-        const frontMatterParameter = { MD025: { "front_matter_title": "" } };
+        const frontMatterParameter = { MD025: { front_matter_title: "" } };
         workspace.getConfiguration().update(markdownlintProperty, frontMatterParameter, ConfigurationTarget.Global);
         showStatusMessage(`Added front_matter_title property to Markdownlint config setting.`);
     }

--- a/docs-linting/src/extension.ts
+++ b/docs-linting/src/extension.ts
@@ -49,7 +49,7 @@ export function checkMarkdownlintCustomProperty() {
         // if the markdownlint.customRules property exists, pull the global values (user settings) into a string.
         if (customPropertyData.globalValue) {
             const valuesToString = customPropertyData.globalValue.toString();
-            var individualValues = valuesToString.split(",");
+            let individualValues = valuesToString.split(",");
             individualValues.forEach((setting: string) => {
                 if (setting === customRuleset) {
                     existingUserSettings.push(setting);
@@ -68,9 +68,9 @@ export function checkMarkdownlintCustomProperty() {
                 output.appendLine(`[${msTimeValue}] - Docs custom markdownlint ruleset added to user settings.`);
             }
 
-            //remove docs-markdown ruleset setting if necessary
+            // remove docs-markdown ruleset setting if necessary
             if (individualValues.indexOf(docsMarkdownRuleset) > -1) {
-                individualValues = existingUserSettings.filter(userSetting => {
+                individualValues = existingUserSettings.filter((userSetting) => {
                     return userSetting !== docsMarkdownRuleset;
                 });
                 workspace.getConfiguration().update(customProperty, individualValues, ConfigurationTarget.Global);


### PR DESCRIPTION
TSLint fixes for rules below:

- Unnecessarily quoted property 'front_matter_title' found.
- Forbidden 'var' keyword, use 'let' or 'const' instead
- Comment must start with a space
- Parentheses are required around the parameters of an arrow function definition