### PR TITLE
Updated activation events for docs article templates.

### DIFF
--- a/docs-article-templates/package.json
+++ b/docs-article-templates/package.json
@@ -13,7 +13,8 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "markdown",
+    "yaml"
   ],
   "main": "./dist/extension",
   "contributes": {


### PR DESCRIPTION
We probably do not want the extension to fire always, we probably only want it to be active when user opens a markdown or yaml document?