### PR TITLE
Update include regex in unused asset removal command

### DIFF
--- a/docs-markdown/src/controllers/cleanup/remove-unused-assets-controller.ts
+++ b/docs-markdown/src/controllers/cleanup/remove-unused-assets-controller.ts
@@ -20,7 +20,7 @@ export function getUnusedImagesAndIncludesCommand() {
 /**
  * Removes all unused images and includes.
  */
-const INCLUDE_RE = /\[!include \[.*\]\((.*)\)\]|<img[^>]+src="([^">]+)"|\((.*?.(?:png|jpg|jpeg|svg|tiff|gif))\s*(?:".*")*\)|source\s*=\s*"(.*?)"|lightbox\s*=\s*"(.*?)"|"\s*source_path\s*"\s*:\s*"(.*?)"|href\s*:\s*(.*)"/gmi;
+const INCLUDE_RE = /\[!include\s?\[.*\]\((.*)\)\]|<img[^>]+src="([^">]+)"|\((.*?.(?:png|jpg|jpeg|svg|tiff|gif))\s*(?:".*")*\)|source\s*=\s*"(.*?)"|lightbox\s*=\s*"(.*?)"|"\s*source_path\s*"\s*:\s*"(.*?)"|href\s*:\s*(.*)"/gmi;
 const message = "Removing unused images and includes. This could take several minutes.";
 export async function removeUnusedImagesAndIncludes(progress: any, workspacePath: string, resolve: any): Promise<any> {
     let unusedFiles = await getImageAndIncludesFiles(workspacePath);


### PR DESCRIPTION
**Include** references that don't contain a space are deleted because the include regex expects one.  This PR allows for an optional space after the opening **include**.

The **esql-md.md** references in this [file ](https://github.com/dotnet/docs/blob/master/docs/framework/data/adonet/ef/entityclient-provider-for-the-entity-framework.md)are examples of the erroneous deletions .  This PR will make these references valid entries and the cleanup command will not flag **esql-md.md** for deletion.