### PR TITLE
Added collapse relative links functionality

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -214,6 +214,11 @@
         "category": "Docs"
       },
       {
+        "command": "collapseRelativeLinks",
+        "title": "Collapse relative links",
+        "category": "Docs"
+      },
+      {
         "command": "sortSelectionAscending",
         "title": "Sort selection ascending (A to Z)",
         "category": "Docs"
@@ -257,6 +262,11 @@
         {
           "when": "editorTextFocus && resourceLangId == markdown || resourceLangId == yaml",
           "command": "updateImplicitMetadataValues",
+          "group": "1_modification"
+        },
+        {
+          "when": "editorTextFocus && resourceLangId == markdown",
+          "command": "collapseRelativeLinks",
           "group": "1_modification"
         },
         {

--- a/docs-markdown/src/ICommand.ts
+++ b/docs-markdown/src/ICommand.ts
@@ -1,0 +1,4 @@
+export interface ICommand {
+    command: string;
+    callback: (...args: any[]) => any;
+}

--- a/docs-markdown/src/controllers/link-controller.ts
+++ b/docs-markdown/src/controllers/link-controller.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "fs";
-import { dirname, join, normalize, relative } from "path";
+import { dirname, join, relative } from "path";
 import { commands, QuickPickItem, QuickPickOptions, window } from "vscode";
 import { checkExtension, noActiveEditorMessage } from "../helper/common";
 import { sendTelemetryData } from "../helper/telemetry";

--- a/docs-markdown/src/controllers/link-controller.ts
+++ b/docs-markdown/src/controllers/link-controller.ts
@@ -1,17 +1,48 @@
+import { existsSync } from "fs";
+import { dirname, join, normalize, relative } from "path";
 import { commands, QuickPickItem, QuickPickOptions, window } from "vscode";
-import { checkExtension } from "../helper/common";
+import { checkExtension, noActiveEditorMessage } from "../helper/common";
 import { sendTelemetryData } from "../helper/telemetry";
+import { applyReplacements, findReplacements, IRegExpWithGroup, Replacements } from "../helper/utility";
 import { Insert, insertURL, MediaType, selectLinkType } from "./media-controller";
 import { applyXref } from "./xref-controller";
 
+const linkRegex: IRegExpWithGroup = { expression: /\]\((?<path>[^http?].+?)\)/gm, group: "path" };
 const telemetryCommand: string = "insertLink";
 let commandOption: string;
 
-export function insertLinkCommand() {
-    return [
-        { command: pickLinkType.name, callback: pickLinkType },
-        { command: insertURL.name, callback: insertURL },
-    ];
+export async function collapseRelativeLinks() {
+    const editor = window.activeTextEditor;
+    if (!editor) {
+        noActiveEditorMessage();
+        return;
+    }
+
+    const content = editor.document.getText();
+    if (!content) {
+        return;
+    }
+
+    const directory = dirname(editor.document.fileName);
+    const tempReplacements = findReplacements(editor.document, content, null, linkRegex);
+    const replacements: Replacements = [];
+    if (tempReplacements) {
+        for (let i = 0; i < tempReplacements.length; i++) {
+            const replacement = tempReplacements[i];
+            const absolutePath = join(directory, replacement.value);
+            if (replacement && existsSync(absolutePath)) {
+                const relativePath = relative(directory, absolutePath).replace(/\\/g, "/");
+                if (relativePath !== replacement.value) {
+                    replacements.push({
+                        selection: replacement.selection,
+                        value: relativePath,
+                    });
+                }
+            }
+        }
+    }
+
+    await applyReplacements(replacements, editor);
 }
 
 export function pickLinkType() {

--- a/docs-markdown/src/controllers/link-controller.ts
+++ b/docs-markdown/src/controllers/link-controller.ts
@@ -7,7 +7,10 @@ import { applyReplacements, findReplacements, IRegExpWithGroup, Replacements } f
 import { Insert, insertURL, MediaType, selectLinkType } from "./media-controller";
 import { applyXref } from "./xref-controller";
 
-const linkRegex: IRegExpWithGroup = { expression: /\]\((?<path>[^http?].+?)\)/gm, group: "path" };
+const linkRegex: IRegExpWithGroup = {
+    expression: /\]\((?<path>[^http?].+?)(?<query>\?.+?)?(?<hash>#.+?)?\)/gm,
+    groups: ["path", "query", "hash"],
+};
 const telemetryCommand: string = "insertLink";
 let commandOption: string;
 

--- a/docs-markdown/src/controllers/link-controller.ts
+++ b/docs-markdown/src/controllers/link-controller.ts
@@ -8,7 +8,7 @@ import { Insert, insertURL, MediaType, selectLinkType } from "./media-controller
 import { applyXref } from "./xref-controller";
 
 const linkRegex: IRegExpWithGroup = {
-    expression: /\]\((?<path>[^http?].+?)(?<query>\?.+?)?(?<hash>#.+?)?\)/gm,
+    expression: /\]\((?<path>[^http?|~].+?)(?<query>\?.+?)?(?<hash>#.+?)?\)/gm,
     groups: ["path", "query", "hash"],
 };
 const telemetryCommand: string = "insertLink";

--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -14,6 +14,7 @@ import { codeFormattingCommand } from "./controllers/code-controller";
 import { insertImageCommand } from "./controllers/image-controller";
 import { insertIncludeCommand } from "./controllers/include-controller";
 import { italicFormattingCommand } from "./controllers/italic-controller";
+import { collapseRelativeLinks } from "./controllers/link-controller";
 import { insertListsCommands } from "./controllers/list-controller";
 import { insertLinksAndMediaCommands } from "./controllers/media-controller";
 import { insertMetadataCommands } from "./controllers/metadata-controller";
@@ -36,8 +37,10 @@ import { tripleColonCompletionItemsProvider } from "./helper/triple-colon-extens
 import { UiHelper } from "./helper/ui";
 import { findAndReplaceTargetExpressions } from "./helper/utility";
 import { isCursorInsideYamlHeader } from "./helper/yaml-metadata";
+import { ICommand } from "./ICommand";
 
 export let extensionPath: string;
+type Commands = ICommand[];
 
 /**
  * Provides the commands to the extension. This method is called when extension is activated.
@@ -60,29 +63,35 @@ export function activate(context: ExtensionContext) {
     installedExtensionsCheck();
 
     // Creates an array of commands from each command file.
-    const AuthoringCommands: any = [];
-    insertAlertCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    insertMonikerCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    insertIncludeCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    insertLinksAndMediaCommands().forEach((cmd) => AuthoringCommands.push(cmd));
-    insertListsCommands().forEach((cmd) => AuthoringCommands.push(cmd));
-    insertSnippetCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    insertTableCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    boldFormattingCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    codeFormattingCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    italicFormattingCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    quickPickMenuCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    previewTopicCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    getMasterRedirectionCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    applyCleanupCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    applyXrefCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    yamlCommands().forEach((cmd) => AuthoringCommands.push(cmd));
-    noLocTextCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    insertRowsAndColumnsCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    insertImageCommand().forEach((cmd) => AuthoringCommands.push(cmd));
-    insertMetadataCommands().forEach((cmd) => AuthoringCommands.push(cmd));
-    insertSortSelectionCommands().forEach((cmd) => AuthoringCommands.push(cmd));
-    insertLanguageCommands().forEach((cmd) => AuthoringCommands.push(cmd));
+    const authoringCommands: Commands = [
+        {
+            callback: collapseRelativeLinks,
+            command: collapseRelativeLinks.name,
+        },
+    ];
+    insertAlertCommand().forEach((cmd) => authoringCommands.push(cmd));
+    insertMonikerCommand().forEach((cmd) => authoringCommands.push(cmd));
+    insertIncludeCommand().forEach((cmd) => authoringCommands.push(cmd));
+    insertLinksAndMediaCommands().forEach((cmd) => authoringCommands.push(cmd));
+    insertListsCommands().forEach((cmd) => authoringCommands.push(cmd));
+    insertSnippetCommand().forEach((cmd) => authoringCommands.push(cmd));
+    insertTableCommand().forEach((cmd) => authoringCommands.push(cmd));
+    boldFormattingCommand().forEach((cmd) => authoringCommands.push(cmd));
+    codeFormattingCommand().forEach((cmd) => authoringCommands.push(cmd));
+    italicFormattingCommand().forEach((cmd) => authoringCommands.push(cmd));
+    quickPickMenuCommand().forEach((cmd) => authoringCommands.push(cmd));
+    previewTopicCommand().forEach((cmd) => authoringCommands.push(cmd));
+    getMasterRedirectionCommand().forEach((cmd) => authoringCommands.push(cmd));
+    applyCleanupCommand().forEach((cmd) => authoringCommands.push(cmd));
+    applyXrefCommand().forEach((cmd) => authoringCommands.push(cmd));
+    yamlCommands().forEach((cmd) => authoringCommands.push(cmd));
+    noLocTextCommand().forEach((cmd) => authoringCommands.push(cmd));
+    insertRowsAndColumnsCommand().forEach((cmd) => authoringCommands.push(cmd));
+    insertImageCommand().forEach((cmd) => authoringCommands.push(cmd));
+    insertMetadataCommands().forEach((cmd) => authoringCommands.push(cmd));
+    insertSortSelectionCommands().forEach((cmd) => authoringCommands.push(cmd));
+    insertLanguageCommands().forEach((cmd) => authoringCommands.push(cmd));
+
     // Autocomplete
     context.subscriptions.push(setupAutoComplete());
     languages.registerDocumentLinkProvider({ language: "markdown" }, {
@@ -112,15 +121,10 @@ export function activate(context: ExtensionContext) {
 
     // Attempts the registration of commands with VS Code and then add them to the extension context.
     try {
-        commands.registerCommand("cleanupFile", async (uri: Uri) => {
-            await applyCleanupFile(uri);
-        });
-        commands.registerCommand("cleanupInFolder", async (uri: Uri) => {
-            await applyCleanupFolder(uri);
-        });
-        AuthoringCommands.map((cmd: any) => {
-            const commandName = cmd.command;
-            const command = commands.registerCommand(commandName, cmd.callback);
+        commands.registerCommand("cleanupFile", async (uri: Uri) => await applyCleanupFile(uri));
+        commands.registerCommand("cleanupInFolder", async (uri: Uri) => await applyCleanupFolder(uri));
+        authoringCommands.map((cmd: ICommand) => {
+            const command = commands.registerCommand(cmd.command, cmd.callback);
             context.subscriptions.push(command);
         });
     } catch (error) {

--- a/docs-markdown/src/helper/highlight-langs.ts
+++ b/docs-markdown/src/helper/highlight-langs.ts
@@ -95,7 +95,7 @@ export const languages: HighlightLanguages =
         { language: "Python", aliases: ["python", "py", "gyp"], extensions: [".py"] },
         { language: "Q#", aliases: ["qsharp"] },
         { language: "R", aliases: ["r"], extensions: [".r"] },
-        { language: "Razor CSHTML", aliases: ["cshtml", "razor", "razor-cshtml"], extensions: [".cshtml", ".razor"] },
+        { language: "Razor CSHTML", aliases: ["razor", "cshtml", "razor-cshtml"], extensions: [".cshtml", ".razor"] },
         { language: "REST API", aliases: ["rest"] },
         { language: "Ruby", aliases: ["ruby", "rb", "gemspec", "podspec", "thor", "irb"], extensions: [".rb"] },
         { language: "SQL", aliases: ["sql"], extensions: [".sql"] },

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -391,7 +391,7 @@ export async function findAndReplaceTargetExpressions(event: TextDocumentChangeE
 
 export interface IRegExpWithGroup {
     expression: RegExp;
-    group: string;
+    groups: string[];
 }
 
 export type RegExpOrRegExpWithGroup = RegExp | IRegExpWithGroup;
@@ -418,20 +418,20 @@ export function findReplacements(document: TextDocument, content: string, value:
         return undefined;
     }
 
-    const group = !isRegExp(expression) ? expression.group : null;
+    const groups = !isRegExp(expression) ? expression.groups : null;
     const replacements: Replacements = [];
     for (let i = 0; i < results.length; i++) {
         const result = results[i];
         if (result !== null && result.length) {
-            const match = (group && result.groups)
-                ? result.groups[group]
+            const match = (groups && result.groups)
+                ? result.groups[groups[0]]
                 : result[0];
             if (match) {
                 let index = result.index !== undefined ? result.index : -1;
                 if (index === -1) {
                     continue;
                 }
-                if (group) {
+                if (groups) {
                     index += result[0].indexOf(match);
                 }
 
@@ -439,7 +439,10 @@ export function findReplacements(document: TextDocument, content: string, value:
                 const endPosition = document.positionAt(index + match.length);
                 const selection = new Selection(startPosition, endPosition);
 
-                replacements.push({ selection, value: value ? value : document.getText(selection) });
+                replacements.push({
+                    selection, value:
+                        value ? value : document.getText(selection)
+                });
             }
         }
     }
@@ -451,20 +454,23 @@ export function findReplacement(document: TextDocument, content: string, value: 
     const exp = isRegExp(expression) ? expression : expression.expression;
     const result = exp ? exp.exec(content) : null;
     if (result !== null && result.length) {
-        const group = !isRegExp(expression) ? expression.group : null;
-        const match = (group && result.groups)
-            ? result.groups[group]
+        const groups = !isRegExp(expression) ? expression.groups : null;
+        const match = (groups && result.groups)
+            ? result.groups[groups[0]]
             : result[0];
         if (match) {
             let index = result.index;
-            if (group) {
+            if (groups) {
                 index += result[0].indexOf(match);
             }
             const startPosition = document.positionAt(index);
             const endPosition = document.positionAt(index + match.length);
             const selection = new Selection(startPosition, endPosition);
 
-            return { selection, value: value ? value : document.getText(selection) };
+            return {
+                selection,
+                value: value ? value : document.getText(selection)
+            };
         }
     }
 

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -389,6 +389,17 @@ export async function findAndReplaceTargetExpressions(event: TextDocumentChangeE
     return event;
 }
 
+export interface IRegExpWithGroup {
+    expression: RegExp;
+    group: string;
+}
+
+export type RegExpOrRegExpWithGroup = RegExp | IRegExpWithGroup;
+
+function isRegExp(expression: RegExpOrRegExpWithGroup): expression is RegExp {
+    return (expression as RegExp).source !== undefined;
+}
+
 export interface IReplacement {
     selection: Selection;
     value: string;
@@ -396,32 +407,39 @@ export interface IReplacement {
 
 export type Replacements = IReplacement[];
 
-export function findReplacements(document: TextDocument, content: string, value: string, expression?: RegExp): Replacements | undefined {
+export function findReplacements(document: TextDocument, content: string, value: string, expression?: RegExpOrRegExpWithGroup): Replacements | undefined {
     if (!expression) {
         return undefined;
     }
 
-    const results = matchAll(expression, content);
+    const exp = isRegExp(expression) ? expression : expression.expression;
+    const results = matchAll(exp, content);
     if (!results || !results.length) {
         return undefined;
     }
 
+    const group = !isRegExp(expression) ? expression.group : null;
     const replacements: Replacements = [];
     for (let i = 0; i < results.length; i++) {
         const result = results[i];
         if (result !== null && result.length) {
-            const match = result[0];
+            const match = (group && result.groups)
+                ? result.groups[group]
+                : result[0];
             if (match) {
-                const index = result.index !== undefined ? result.index : -1;
+                let index = result.index !== undefined ? result.index : -1;
                 if (index === -1) {
                     continue;
+                }
+                if (group) {
+                    index += result[0].indexOf(match);
                 }
 
                 const startPosition = document.positionAt(index);
                 const endPosition = document.positionAt(index + match.length);
                 const selection = new Selection(startPosition, endPosition);
 
-                replacements.push({ selection, value });
+                replacements.push({ selection, value: value ? value : document.getText(selection) });
             }
         }
     }
@@ -429,17 +447,24 @@ export function findReplacements(document: TextDocument, content: string, value:
     return replacements;
 }
 
-export function findReplacement(document: TextDocument, content: string, value: string, expression?: RegExp): IReplacement | undefined {
-    const result = expression ? expression.exec(content) : null;
+export function findReplacement(document: TextDocument, content: string, value: string, expression?: RegExpOrRegExpWithGroup): IReplacement | undefined {
+    const exp = isRegExp(expression) ? expression : expression.expression;
+    const result = exp ? exp.exec(content) : null;
     if (result !== null && result.length) {
-        const match = result[0];
+        const group = !isRegExp(expression) ? expression.group : null;
+        const match = (group && result.groups)
+            ? result.groups[group]
+            : result[0];
         if (match) {
-            const index = result.index;
+            let index = result.index;
+            if (group) {
+                index += result[0].indexOf(match);
+            }
             const startPosition = document.positionAt(index);
             const endPosition = document.positionAt(index + match.length);
             const selection = new Selection(startPosition, endPosition);
 
-            return { selection, value };
+            return { selection, value: value ? value : document.getText(selection) };
         }
     }
 
@@ -447,7 +472,7 @@ export function findReplacement(document: TextDocument, content: string, value: 
 }
 
 export async function applyReplacements(replacements: Replacements, editor: TextEditor) {
-    if (replacements) {
+    if (replacements && replacements.length) {
         await editor.edit((builder) => {
             replacements.forEach((replacement) =>
                 builder.replace(

--- a/docs-markdown/src/helper/utility.ts
+++ b/docs-markdown/src/helper/utility.ts
@@ -441,7 +441,7 @@ export function findReplacements(document: TextDocument, content: string, value:
 
                 replacements.push({
                     selection, value:
-                        value ? value : document.getText(selection)
+                        value ? value : document.getText(selection),
                 });
             }
         }
@@ -469,7 +469,7 @@ export function findReplacement(document: TextDocument, content: string, value: 
 
             return {
                 selection,
-                value: value ? value : document.getText(selection)
+                value: value ? value : document.getText(selection),
             };
         }
     }


### PR DESCRIPTION
Added collapse relative links functionality. Inspired by pull requests such as this:

- https://github.com/dotnet/docs/pull/18461
- https://github.com/dotnet/docs/pull/18471
- https://github.com/dotnet/docs/pull/18472
- https://github.com/dotnet/docs/pull/18497
- etc...

Automate this functionality with the click of a button, I hope that @NextTurn will appreciate this addition 🎉 

![collapse-rel-links](https://user-images.githubusercontent.com/7679720/82337512-79350380-99b1-11ea-8da2-26e4f6a0ce83.gif)

Validated the following link examples:

```markdown
[Link 1](http://microsoft.com)
[Link 2](https://microsoft.com)
[Link 3](link.md)
[Link 4](/link.md)
[Link 5](./link.md)
[Link 6](../link.md)
[Link 7](~/link.md)
[Link 8](../../link.md?q=1)
[Link 9](../../link.md#bookmark)
[Link 10](../../../link.md?q=1#bookmark)
```

Using this JavaScript RegExp:

```typescript
linkRegExp: RegExp = /\]\((?<path>[^http?|~].+?)(?<query>\?.+?)?(?<hash>#.+?)?\)/gm;
```