### PR TITLE
Collapse in folder

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -219,6 +219,11 @@
         "category": "Docs"
       },
       {
+        "command": "collapseRelativeLinksInFolder",
+        "title": "Collapse relative links in folder",
+        "category": "Docs"
+      },
+      {
         "command": "sortSelectionAscending",
         "title": "Sort selection ascending (A to Z)",
         "category": "Docs"
@@ -291,6 +296,11 @@
         }
       ],
       "explorer/context": [
+        {
+          "command": "collapseRelativeLinksInFolder",
+          "group": "1_modification",
+          "when": "explorerResourceIsFolder"
+        },
         {
           "command": "cleanupInFolder",
           "group": "1_modification",

--- a/docs-markdown/src/controllers/link-controller.ts
+++ b/docs-markdown/src/controllers/link-controller.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "fs";
 import { dirname, join, relative } from "path";
-import { commands, ProgressLocation, QuickPickItem, QuickPickOptions, RelativePattern, Uri, window, workspace, TextEditor } from "vscode";
+import { commands, ProgressLocation, QuickPickItem, QuickPickOptions, RelativePattern, TextEditor, Uri, window, workspace } from "vscode";
 import { checkExtension, noActiveEditorMessage } from "../helper/common";
 import { sendTelemetryData } from "../helper/telemetry";
 import { applyReplacements, findReplacements, IRegExpWithGroup, Replacements } from "../helper/utility";

--- a/docs-markdown/src/controllers/link-controller.ts
+++ b/docs-markdown/src/controllers/link-controller.ts
@@ -26,7 +26,7 @@ const linkRegex: IRegExpWithGroup = {
 const telemetryCommand: string = "insertLink";
 let commandOption: string;
 
-async function collapseRelativeLinksInFolder(uri: Uri) {
+export async function collapseRelativeLinksInFolder(uri: Uri) {
     await window.withProgress({
         location: ProgressLocation.Window,
     }, async (progress) => {
@@ -40,19 +40,21 @@ async function collapseRelativeLinksInFolder(uri: Uri) {
             const file = filePaths[i];
             const document = await workspace.openTextDocument(file);
             const editor = await window.showTextDocument(document, undefined, false);
-            await collapseRelativeLinksForEditor(editor);
-            progress.report({ increment: 1 });
+            const replaced = await collapseRelativeLinksForEditor(editor);
+            if (replaced > 0) {
+                progress.report({ increment: 1, message: `Collapsed ${replaced} links in ${file}.` });
+            }
         }
 
         progress.report({ increment: 100, message: `Collapsed links in ${length} files.` });
     });
 }
 
-async function collapseRelativeLinks() {
+export async function collapseRelativeLinks() {
     await collapseRelativeLinksForEditor(window.activeTextEditor);
 }
 
-async function collapseRelativeLinksForEditor(editor: TextEditor) {
+export async function collapseRelativeLinksForEditor(editor: TextEditor): Promise<number> {
     if (!editor) {
         noActiveEditorMessage();
         return;
@@ -83,6 +85,7 @@ async function collapseRelativeLinksForEditor(editor: TextEditor) {
     }
 
     await applyReplacements(replacements, editor);
+    return replacements.length;
 }
 
 export function pickLinkType() {

--- a/docs-markdown/src/controllers/link-controller.ts
+++ b/docs-markdown/src/controllers/link-controller.ts
@@ -1,11 +1,23 @@
 import { existsSync } from "fs";
 import { dirname, join, relative } from "path";
-import { commands, QuickPickItem, QuickPickOptions, window } from "vscode";
+import { commands, ProgressLocation, QuickPickItem, QuickPickOptions, RelativePattern, Uri, window, workspace, TextEditor } from "vscode";
 import { checkExtension, noActiveEditorMessage } from "../helper/common";
 import { sendTelemetryData } from "../helper/telemetry";
 import { applyReplacements, findReplacements, IRegExpWithGroup, Replacements } from "../helper/utility";
+import { ICommand } from "../ICommand";
 import { Insert, insertURL, MediaType, selectLinkType } from "./media-controller";
 import { applyXref } from "./xref-controller";
+
+export const linkControllerCommands: ICommand[] = [
+    {
+        callback: collapseRelativeLinks,
+        command: collapseRelativeLinks.name,
+    },
+    {
+        callback: collapseRelativeLinksInFolder,
+        command: collapseRelativeLinksInFolder.name,
+    },
+];
 
 const linkRegex: IRegExpWithGroup = {
     expression: /\]\((?<path>[^http?|~].+?)(?<query>\?.+?)?(?<hash>#.+?)?\)/gm,
@@ -14,8 +26,33 @@ const linkRegex: IRegExpWithGroup = {
 const telemetryCommand: string = "insertLink";
 let commandOption: string;
 
-export async function collapseRelativeLinks() {
-    const editor = window.activeTextEditor;
+async function collapseRelativeLinksInFolder(uri: Uri) {
+    await window.withProgress({
+        location: ProgressLocation.Window,
+    }, async (progress) => {
+        const filePaths =
+            await workspace.findFiles(
+                new RelativePattern(uri.path, "**/*.md"));
+
+        const length = filePaths.length;
+        progress.report({ increment: 1, message: `Collapsing links in ${length} files.` });
+        for (let i = 0; i < length; i++) {
+            const file = filePaths[i];
+            const document = await workspace.openTextDocument(file);
+            const editor = await window.showTextDocument(document, undefined, false);
+            await collapseRelativeLinksForEditor(editor);
+            progress.report({ increment: 1 });
+        }
+
+        progress.report({ increment: 100, message: `Collapsed links in ${length} files.` });
+    });
+}
+
+async function collapseRelativeLinks() {
+    await collapseRelativeLinksForEditor(window.activeTextEditor);
+}
+
+async function collapseRelativeLinksForEditor(editor: TextEditor) {
     if (!editor) {
         noActiveEditorMessage();
         return;

--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -14,7 +14,7 @@ import { codeFormattingCommand } from "./controllers/code-controller";
 import { insertImageCommand } from "./controllers/image-controller";
 import { insertIncludeCommand } from "./controllers/include-controller";
 import { italicFormattingCommand } from "./controllers/italic-controller";
-import { collapseRelativeLinks } from "./controllers/link-controller";
+import { linkControllerCommands } from "./controllers/link-controller";
 import { insertListsCommands } from "./controllers/list-controller";
 import { insertLinksAndMediaCommands } from "./controllers/media-controller";
 import { insertMetadataCommands } from "./controllers/metadata-controller";
@@ -63,12 +63,7 @@ export function activate(context: ExtensionContext) {
     installedExtensionsCheck();
 
     // Creates an array of commands from each command file.
-    const authoringCommands: Commands = [
-        {
-            callback: collapseRelativeLinks,
-            command: collapseRelativeLinks.name,
-        },
-    ];
+    const authoringCommands: Commands = [...linkControllerCommands];
     insertAlertCommand().forEach((cmd) => authoringCommands.push(cmd));
     insertMonikerCommand().forEach((cmd) => authoringCommands.push(cmd));
     insertIncludeCommand().forEach((cmd) => authoringCommands.push(cmd));

--- a/docs-markdown/src/test/data/repo/articles/link-controller.md
+++ b/docs-markdown/src/test/data/repo/articles/link-controller.md
@@ -1,0 +1,10 @@
+# This is a test
+
+[Link 1](http://not-secure-site.com)
+[Link 2](https://microsoft.com)
+[Link 3](~/subdir/sub-link-controller.md?q=1)
+[Link 4](subdir/not-existing-file.md)
+[Link 5](./subdir/sub-link-controller.md?q=1)
+[Link 6](../articles/subdir/sub-link-controller.md#bookmark)
+[Link 7](../../repo/articles/subdir/sub-link-controller.md?q=1#bookmark)
+[Link 8](../../../data/repo/articles/subdir/sub-link-controller.md?q=1#bookmark)

--- a/docs-markdown/src/test/data/repo/articles/subdir/sub-link-controller.md
+++ b/docs-markdown/src/test/data/repo/articles/subdir/sub-link-controller.md
@@ -1,0 +1,5 @@
+# Used for testing
+
+Nothing to see here, move along.
+
+[Link to parent](../../articles/link-controller.md)

--- a/docs-markdown/src/test/suite/controllers/italic-controller.test.ts
+++ b/docs-markdown/src/test/suite/controllers/italic-controller.test.ts
@@ -1,7 +1,7 @@
 import * as chai from "chai";
 import * as spies from "chai-spies";
 import { resolve } from "path";
-import { commands, window, Selection } from "vscode";
+import { commands, Selection, window } from "vscode";
 import { formatItalic, italicFormattingCommand } from "../../../controllers/italic-controller";
 import * as common from "../../../helper/common";
 import * as telemetry from "../../../helper/telemetry";
@@ -90,8 +90,8 @@ suite("Italic Controller", () => {
         const toPositionTwo = cursorPosition.with(48, 17);
         editor!.selections = [
             new Selection(fromPositionOne, toPositionOne),
-            new Selection(fromPositionTwo, toPositionTwo)
-        ]
+            new Selection(fromPositionTwo, toPositionTwo),
+        ];
         const stub = sinon.stub(telemetry, "sendTelemetryData");
         formatItalic();
         await sleep(100);

--- a/docs-markdown/src/test/suite/controllers/link-controller.test.ts
+++ b/docs-markdown/src/test/suite/controllers/link-controller.test.ts
@@ -2,7 +2,9 @@ import * as chai from "chai";
 import { resolve } from "path";
 import { commands, window } from "vscode";
 import {
+    collapseRelativeLinks,
     collapseRelativeLinksForEditor,
+    collapseRelativeLinksInFolder,
     linkControllerCommands,
 } from "../../../controllers/link-controller";
 import * as common from "../../../helper/common";
@@ -17,8 +19,8 @@ suite("Link Controller", () => {
     suiteTeardown(async () => await commands.executeCommand("workbench.action.closeAllEditors"));
     test("italicFormattingCommand", () => {
         const controllerCommands = [
-            { callback: linkControllerCommands[0].callback, command: "collapseRelativeLinks" },
-            { callback: linkControllerCommands[1].callback, command: "collapseRelativeLinksInFolder" },
+            { callback: collapseRelativeLinks, command: "collapseRelativeLinks" },
+            { callback: collapseRelativeLinksInFolder, command: "collapseRelativeLinksInFolder" },
         ];
         expect(linkControllerCommands).to.deep.equal(controllerCommands);
     });

--- a/docs-markdown/src/test/suite/controllers/link-controller.test.ts
+++ b/docs-markdown/src/test/suite/controllers/link-controller.test.ts
@@ -1,0 +1,36 @@
+import * as chai from "chai";
+import { resolve } from "path";
+import { commands, window } from "vscode";
+import {
+    collapseRelativeLinksForEditor,
+    linkControllerCommands,
+} from "../../../controllers/link-controller";
+import * as common from "../../../helper/common";
+import { loadDocumentAndGetItReady } from "../../test.common/common";
+
+// tslint:disable-next-line: no-var-requires
+const expect = chai.expect;
+
+suite("Link Controller", () => {
+    // Reset and tear down the spies
+    teardown(() => chai.spy.restore(common));
+    suiteTeardown(async () => await commands.executeCommand("workbench.action.closeAllEditors"));
+    test("italicFormattingCommand", () => {
+        const controllerCommands = [
+            { callback: linkControllerCommands[0].callback, command: "collapseRelativeLinks" },
+            { callback: linkControllerCommands[1].callback, command: "collapseRelativeLinksInFolder" },
+        ];
+        expect(linkControllerCommands).to.deep.equal(controllerCommands);
+    });
+    test("noActiveEditorMessage", async () => {
+        const spy = chai.spy.on(common, "noActiveEditorMessage");
+        await collapseRelativeLinksForEditor(null);
+        expect(spy).to.have.been.called();
+    });
+    test("Collapse relative links", async () => {
+        const filePath = resolve(__dirname, "../../../../../src/test/data/repo/articles/link-controller.md");
+        await loadDocumentAndGetItReady(filePath);
+        const replacements = await collapseRelativeLinksForEditor(window.activeTextEditor);
+        expect(replacements).to.equal(4);
+    });
+});


### PR DESCRIPTION
Added the ability to call "Collapse relative links in folder" from the explorer context menu. Also, cleanup lint violations from recent merges.

![collapse-rel-links-in-folder](https://user-images.githubusercontent.com/7679720/82449593-1440e280-9a71-11ea-91df-9c1aaa1ec78d.gif)
