### PR TITLE
Fix master redirect command

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -23,6 +23,7 @@
     "markdown"
   ],
   "activationEvents": [
+    "onLanguage:json",
     "onLanguage:markdown",
     "onLanguage:yaml"
   ],

--- a/docs-markdown/src/controllers/redirects/daisyChainResolution.ts
+++ b/docs-markdown/src/controllers/redirects/daisyChainResolution.ts
@@ -11,8 +11,8 @@ export async function applyRedirectDaisyChainResolution() {
     const { config, editor, options, redirects } = redirectsAndConfigOptions;
     const redirectsLookup = new Map<string, { redirect: RedirectUrl | null, redirection: IMasterRedirection }>();
     redirects.redirections.forEach((r) => {
-        redirectsLookup.set(r.sourcePath, {
-            redirect: RedirectUrl.parse(options, r.redirectUrl),
+        redirectsLookup.set(r.source_path, {
+            redirect: RedirectUrl.parse(options, r.redirect_url),
             redirection: r,
         });
     });
@@ -56,18 +56,18 @@ export async function applyRedirectDaisyChainResolution() {
             targetRedirect = findRedirect(daisyChainPath);
         }
 
-        if (targetRedirectUrl && targetRedirectUrl !== source.redirection.redirectUrl) {
+        if (targetRedirectUrl && targetRedirectUrl !== source.redirection.redirect_url) {
             daisyChainsResolved++;
             const newRedirectUrl =
                 isExternalUrl
                     ? targetRedirectUrl
                     : source.redirect!.adaptHashAndQueryString(targetRedirectUrl);
-            source.redirection.redirectUrl = newRedirectUrl;
+            source.redirection.redirect_url = newRedirectUrl;
 
-            if (source.redirection.redirectDocumentId) {
+            if (source.redirection.redirect_document_id) {
                 if (isExternalUrl ||
                     !newRedirectUrl.startsWith(`/${options.docsetName}/`)) {
-                    source.redirection.redirectDocumentId = false;
+                    source.redirection.redirect_document_id = false;
                 }
             }
         }

--- a/docs-markdown/src/controllers/redirects/generateRedirectionFile.ts
+++ b/docs-markdown/src/controllers/redirects/generateRedirectionFile.ts
@@ -103,15 +103,15 @@ export async function generateMasterRedirectionFile(rootPath?: string, done?: an
                     const existingSourcePath: string[] = [];
 
                     masterRedirection.redirections.forEach((item) => {
-                        if (!item.sourcePath) {
+                        if (!item.source_path) {
                             showStatusMessage("An array is missing the sourcePath value. Please check .openpublishing.redirection.json.");
                             return;
                         }
-                        existingSourcePath.push(item.sourcePath.toLowerCase());
+                        existingSourcePath.push(item.source_path.toLowerCase());
                     });
 
                     redirectionFiles.forEach((item) => {
-                        if (existingSourcePath.indexOf(item.sourcePath.toLowerCase()) >= 0) {
+                        if (existingSourcePath.indexOf(item.source_path.toLowerCase()) >= 0) {
                             item.isAlreadyInMasterRedirectionFile = true;
                         } else {
                             if (masterRedirection != null) {
@@ -127,7 +127,7 @@ export async function generateMasterRedirectionFile(rootPath?: string, done?: an
                 }
                 if (masterRedirection.redirections.length > 0) {
                     masterRedirection.redirections.sort((a, b) => {
-                        return naturalLanguageCompare(a.sourcePath, b.sourcePath);
+                        return naturalLanguageCompare(a.source_path, b.source_path);
                     });
 
                     fs.writeFileSync(
@@ -161,7 +161,7 @@ export async function generateMasterRedirectionFile(rootPath?: string, done?: an
 
                     redirectionFiles.forEach((item) => {
                         const source = fs.createReadStream(item.fileFullPath);
-                        const dest = fs.createWriteStream(join(deletedRedirectsPath, basename(item.sourcePath)));
+                        const dest = fs.createWriteStream(join(deletedRedirectsPath, basename(item.source_path)));
 
                         source.pipe(dest);
                         source.on("close", () => {

--- a/docs-markdown/src/controllers/redirects/generateRedirectionFile.ts
+++ b/docs-markdown/src/controllers/redirects/generateRedirectionFile.ts
@@ -132,7 +132,7 @@ export async function generateMasterRedirectionFile(rootPath?: string, done?: an
 
                     fs.writeFileSync(
                         masterRedirectionFilePath,
-                        JSON.stringify(masterRedirection, ["redirections", "sourcePath", "redirect_url", "redirect_document_id"], 4));
+                        JSON.stringify(masterRedirection, ["redirections", "source_path", "redirect_url", "redirect_document_id"], 4));
 
                     const currentYear = date.getFullYear();
                     const currentMonth = (date.getMonth() + 1);

--- a/docs-markdown/src/controllers/redirects/redirect-url.ts
+++ b/docs-markdown/src/controllers/redirects/redirect-url.ts
@@ -19,7 +19,6 @@ export class RedirectUrl {
         return this.url.host.toLocaleLowerCase() !== DocsMicrosoftCom;
     }
 
-    // tslint:disable-next-line: variable-name
     private _filePath: string = "";
     get filePath(): string {
         if (!!this._filePath) {

--- a/docs-markdown/src/controllers/redirects/redirect-url.ts
+++ b/docs-markdown/src/controllers/redirects/redirect-url.ts
@@ -19,6 +19,7 @@ export class RedirectUrl {
         return this.url.host.toLocaleLowerCase() !== DocsMicrosoftCom;
     }
 
+    // tslint:disable: variable-name
     private _filePath: string = "";
     get filePath(): string {
         if (!!this._filePath) {

--- a/docs-markdown/src/controllers/redirects/redirection.ts
+++ b/docs-markdown/src/controllers/redirects/redirection.ts
@@ -8,15 +8,15 @@ export class RedirectionFile implements IMasterRedirection {
     public resource: any;
 
     // Members mapping to JSON elements in master redirection file
-    public sourcePath: string;
-    public redirectUrl: string;
-    public redirectDocumentId: boolean = false;
+    public source_path: string;
+    public redirect_url: string;
+    public redirect_document_id: boolean = false;
 
     constructor(filePath: string, redirectUrl: string, redirectDocumentId: boolean, folder: WorkspaceFolder | undefined) {
         this.fileFullPath = filePath;
-        this.sourcePath = this.getRelativePathToRoot(filePath, folder);
-        this.redirectUrl = redirectUrl;
-        this.redirectDocumentId = redirectDocumentId;
+        this.source_path = this.getRelativePathToRoot(filePath, folder);
+        this.redirect_url = redirectUrl;
+        this.redirect_document_id = redirectDocumentId;
     }
 
     public getRelativePathToRoot(filePath: any, folder: WorkspaceFolder | undefined): string {

--- a/docs-markdown/src/controllers/redirects/redirection.ts
+++ b/docs-markdown/src/controllers/redirects/redirection.ts
@@ -8,6 +8,7 @@ export class RedirectionFile implements IMasterRedirection {
     public resource: any;
 
     // Members mapping to JSON elements in master redirection file
+    // tslint:disable: variable-name
     public source_path: string;
     public redirect_url: string;
     public redirect_document_id: boolean = false;

--- a/docs-markdown/src/controllers/redirects/removeDefaultJsonValues.ts
+++ b/docs-markdown/src/controllers/redirects/removeDefaultJsonValues.ts
@@ -14,7 +14,7 @@ export async function removeDefaultValuesInRedirects() {
 
     let removedDefaults = 0;
     redirects.redirections.forEach((redirect) => {
-        if (redirect.redirectDocumentId === false) {
+        if (redirect.redirect_document_id === false) {
             removedDefaults++;
         }
     });

--- a/docs-markdown/src/controllers/redirects/removeInvalidRedirectDocIds.ts
+++ b/docs-markdown/src/controllers/redirects/removeInvalidRedirectDocIds.ts
@@ -14,11 +14,11 @@ export async function detectInvalidDocumentIdRedirects() {
     const { config, editor, folder, options, redirects } = redirectsAndConfigOptions;
     const redirectsLookup = new Map<string, { redirect: RedirectUrl | null, redirection: IMasterRedirection }>();
     redirects.redirections.forEach((r) => {
-        if (!r.redirectDocumentId) {
+        if (!r.redirect_document_id) {
             return;
         }
-        redirectsLookup.set(r.sourcePath, {
-            redirect: RedirectUrl.parse(options, r.redirectUrl),
+        redirectsLookup.set(r.source_path, {
+            redirect: RedirectUrl.parse(options, r.redirect_url),
             redirection: r,
         });
     });
@@ -59,15 +59,15 @@ export async function detectInvalidDocumentIdRedirects() {
                     return;
                 }
 
-                if (!!redirect.redirectDocumentId) {
+                if (!!redirect.redirect_document_id) {
                     if (url.isExternalUrl) {
-                        redirect.redirectDocumentId = false;
+                        redirect.redirect_document_id = false;
                         fixes++;
                         return;
                     }
 
-                    if (!redirect.redirectUrl.startsWith(`/${options.docsetName}/`)) {
-                        redirect.redirectDocumentId = false;
+                    if (!redirect.redirect_url.startsWith(`/${options.docsetName}/`)) {
+                        redirect.redirect_document_id = false;
                         fixes++;
                         return;
                     }
@@ -78,7 +78,7 @@ export async function detectInvalidDocumentIdRedirects() {
                         url.filePath.replace(".md", "/index.yml"),
                     ];
                     if (!files.some((path: string) => fileExists(path))) {
-                        redirect.redirectDocumentId = false;
+                        redirect.redirect_document_id = false;
                         fixes++;
                         return;
                     }

--- a/docs-markdown/src/controllers/redirects/sortRedirects.ts
+++ b/docs-markdown/src/controllers/redirects/sortRedirects.ts
@@ -9,7 +9,7 @@ export async function sortMasterRedirectionFile() {
 
     const { config, editor, redirects } = redirectsAndConfigOptions;
     redirects.redirections.sort((a, b) => {
-        return naturalLanguageCompare(a.sourcePath, b.sourcePath);
+        return naturalLanguageCompare(a.source_path, b.source_path);
     });
 
     await updateRedirects(editor, redirects, config);

--- a/docs-markdown/src/controllers/redirects/utilities.ts
+++ b/docs-markdown/src/controllers/redirects/utilities.ts
@@ -10,9 +10,9 @@ export interface IMasterRedirections {
 }
 
 export interface IMasterRedirection {
-    sourcePath: string;
-    redirectUrl: string;
-    redirectDocumentId?: boolean;
+    source_path: string;
+    redirect_url: string;
+    redirect_document_id?: boolean;
 }
 
 export class MasterRedirection implements IMasterRedirections {


### PR DESCRIPTION
The source_path value was deleted from .openpublishing.redirection.json when the redirection script was run.  This PR fixes that issue.  Updated the activation events to include json files.