### PR TITLE
Add new condition to insertNestedList command

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -669,7 +669,7 @@
 				"command": "insertNestedList",
 				"key": "tab",
 				"mac": "tab",
-				"when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible && !vim.active"
+				"when": "editorTextFocus && editorLangId == markdown && !suggestWidgetVisible && !vim.active && !inSnippetMode"
 			},
 			{
 				"command": "formatBold",


### PR DESCRIPTION
Docs-markdown shouldn't override `Tab` in snippets.