### PR TITLE
Production Release for docs-markdown, docs-preview, and docs-linting

### DIFF
--- a/docs-linting/changelog.md
+++ b/docs-linting/changelog.md
@@ -1,14 +1,14 @@
 # Change Log
 
-## 0.0.4 (06/04/2020)
+## 0.0.4 (June 4th, 2020)
 
 - Added more moniker linting
 - Added video extension linting
 
-## 0.0.2 (02/25/2020)
+## 0.0.2 (May 25th, 2020)
 
 - Bug fix for where xref is throwing linting error in false positive.
 
-## 0.0.1 (02/25/2020)
+## 0.0.1 (February 25th, 2020)
 
 - First release.

--- a/docs-linting/changelog.md
+++ b/docs-linting/changelog.md
@@ -1,9 +1,14 @@
 # Change Log
 
-## 0.0.2 (2/25/2020, 2018)
+## 0.0.4 (06/04/2020)
 
-Bug fix for where xref is throwing linting error in false positive.
+- Added more moniker linting
+- Added video extension linting
 
-## 0.0.1 (2/25/2020, 2018)
+## 0.0.2 (02/25/2020)
 
-First release.
+- Bug fix for where xref is throwing linting error in false positive.
+
+## 0.0.1 (02/25/2020)
+
+- First release.

--- a/docs-linting/package.json
+++ b/docs-linting/package.json
@@ -3,7 +3,7 @@
 	"displayName": "docs-linting",
 	"description": "Docs Linting Extension",
 	"icon": "images/docs-logo-ms.png",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"publisher": "docsmsft",
 	"homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-linting",
 	"bugs": {

--- a/docs-markdown/changelog.md
+++ b/docs-markdown/changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.2.72 (June 4th, 2020)
+
+- Added support for triple colon video extension insertion.
+- Bug fix for Link in repo.
+- Updated collapse relative link feature.
+
 ## 0.2.71 (May 29th, 2020)
 
 - Improved support for collapse relative links in folder experience.

--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -4,7 +4,7 @@
 	"description": "Docs Markdown Extension",
 	"icon": "images/docs-logo-ms.png",
 	"aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-	"version": "0.2.71",
+	"version": "0.2.72",
 	"publisher": "docsmsft",
 	"homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
 	"bugs": {

--- a/docs-preview/changelog.md
+++ b/docs-preview/changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.3.51 (June 4th, 2020)
+
+- Added triple colon video extension support.
+- Bug fix for preview refresh on xref and codesnippet extensions.
+
 ## 0.3.50 (May 22nd, 2020)
 
 - Added clickable triple colon image support for preview.

--- a/docs-preview/package.json
+++ b/docs-preview/package.json
@@ -3,7 +3,7 @@
 	"displayName": "docs-preview",
 	"description": "Docs Markdown Preview Extension",
 	"aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-	"version": "0.3.50",
+	"version": "0.3.51",
 	"publisher": "docsmsft",
 	"icon": "images/docs-logo-ms.png",
 	"bugs": {


### PR DESCRIPTION
Production Release for docs-markdown, docs-preview, and docs-linting

docs-markdown:
- Added support for triple colon video extension insertion.
- Bug fix for Link in repo.
- Updated collapse relative link feature.

docs-preview:
- Added triple colon video extension support.
- Bug fix for preview refresh on xref and codesnippet extensions.

docs-linting:
- Added more moniker linting
- Added video extension linting