### PR TITLE
Remove preview and template commands from command palette

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -453,16 +453,6 @@
 					"when": "resourceLangId == markdown"
 				},
 				{
-					"command": "previewTopic",
-					"group": "Docs",
-					"when": "resourceLangId == markdown && vscode.extensions.getExtension('docsmsft.docs-preview').active"
-				},
-				{
-					"command": "applyTemplate",
-					"group": "Docs",
-					"when": "vscode.extensions.getExtension('docsmsft.docs-article-templates').active"
-				},
-				{
 					"command": "applyCleanup",
 					"group": "Docs",
 					"when": "resourceLangId == markdown"


### PR DESCRIPTION
The [preview](https://github.com/microsoft/vscode-docs-authoring/blob/master/docs-preview/package.json#L93) and [template](https://github.com/microsoft/vscode-docs-authoring/blob/master/docs-article-templates/package.json#L51) commands are added through their respective extensions so we don't need to add them docs-markdown.