### PR TITLE
docs-images production release

### DIFF
--- a/docs-images/CHANGELOG.md
+++ b/docs-images/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.0.9 (June 12th, 2020)
+
+- Upgrade dependency versions
+- Import from es and enable interop
+- Add timeout with delay to prevent hangs
+- Do not use arithmetic coding with JPG compression
+- Added mime-type validation to ensure that the file type is actually the same as the assumed type from the file extension
+
 ## 0.0.4 (April 2nd, 2020)
 
 - Bundling with webpack.

--- a/docs-images/package.json
+++ b/docs-images/package.json
@@ -3,7 +3,7 @@
 	"displayName": "docs-images",
 	"description": "Docs Images Extension",
 	"icon": "images/docs-logo-ms.png",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"publisher": "docsmsft",
 	"homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-images",
 	"bugs": {


### PR DESCRIPTION
Updated package.json and changelog. Changes include:
- Upgrade dependency versions
- Import from es and enable interop
- Add timeout with delay to prevent hangs
- Do not use arithmetic coding with JPG compression
- Added mime-type validation to ensure that the file type is actually the same as the assumed type from the file extension