### PR TITLE
Update Markdown extensions list

### DIFF
--- a/docs-linting/markdownlint-custom-rules/common.js
+++ b/docs-linting/markdownlint-custom-rules/common.js
@@ -10,7 +10,7 @@ module.exports.AttributeMatch = /(\S+)=["]?((?:.(?!["]?\s+(?:\S+)=|["]))+.)["]?/
 
 // Markdown extensions (add valid/supported extensions to list)
 module.exports.openExtension = /^:(.*?)(zone|moniker|no-loc)/gm;
-module.exports.supportedExtensions = /^:::\s?(zone|moniker|row|column|form|no-loc|image|code|video)(.:*)?/g;
+module.exports.supportedExtensions = /^:::\s?(zone|moniker|row|column|form|no-loc|image|code|video|notes)(.:*)?/g;
 module.exports.unsupportedExtensionRegex = /^:::\s+(.*)/gm;
 
 // Zones


### PR DESCRIPTION
This is a small change to add ``notes`` to the list of supported Markdown extensions.

This should resolve the issue noted in #583.