### PR TITLE
Add extension mode property and bump vscode version

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -11,7 +11,7 @@
 		"url": "https://github.com/Microsoft/vscode-docs-authoring/issues"
 	},
 	"engines": {
-		"vscode": "1.46.0"
+		"vscode": "^1.47.0"
 	},
 	"repository": {
 		"url": "https://github.com/Microsoft/vscode-docs-authoring.git"
@@ -772,7 +772,7 @@
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^12.12.32",
 		"@types/recursive-readdir": "^2.2.0",
-		"@types/vscode": "1.46.0",
+		"@types/vscode": "^1.47.0",
 		"@types/yamljs": "^0.2.30",
 		"@typescript-eslint/eslint-plugin": "^2.34.0",
 		"@typescript-eslint/eslint-plugin-tslint": "^2.34.0",

--- a/docs-markdown/src/controllers/cleanup/devlangsInCodeBlocks.ts
+++ b/docs-markdown/src/controllers/cleanup/devlangsInCodeBlocks.ts
@@ -18,6 +18,7 @@ export function cleanUpDevLangInCodeBlocks(
 	if (file.endsWith('.md')) {
 		return readWriteFileWithProgress(progress, file, message, files, index, (data: string) => {
 			data = findCodeBlocks(data);
+			data = convertDevlang(data);
 			return data;
 		});
 	} else {
@@ -39,9 +40,8 @@ export function lowercaseDevlang(data: string, regex: RegExp) {
 				return match.toLowerCase();
 			});
 		});
-		convertDevlang(data);
-		return data;
 	}
+	return data;
 }
 
 export function convertDevlang(data: string) {
@@ -50,7 +50,5 @@ export function convertDevlang(data: string) {
 	data = data.replace(csharpRegex, '```csharp');
 	const markdownRegex = new RegExp(/```markdown\s/gi);
 	data = data.replace(markdownRegex, '```md');
-	// eslint-disable-next-line no-console
-	console.log(data);
 	return data;
 }

--- a/docs-markdown/src/test/suite/controllers/quick-pick-menu-controller.test.ts
+++ b/docs-markdown/src/test/suite/controllers/quick-pick-menu-controller.test.ts
@@ -3,7 +3,15 @@ import * as chai from 'chai';
 import * as spies from 'chai-spies';
 import * as telemetry from '../../../helper/telemetry';
 import { resolve } from 'path';
-import { commands, QuickPickItem, window, workspace, ExtensionContext, Uri } from 'vscode';
+import {
+	commands,
+	QuickPickItem,
+	window,
+	workspace,
+	ExtensionContext,
+	Uri,
+	ExtensionMode
+} from 'vscode';
 import * as boldController from './../../../controllers/bold-controller';
 import * as italicController from '../../../controllers/italic-controller';
 import * as codeController from '../../../controllers/code-controller';
@@ -67,7 +75,8 @@ const context: ExtensionContext = {
 		forEach: () => {},
 		clear: () => {},
 		delete: () => {}
-	}
+	},
+	extensionMode: ExtensionMode.Test
 };
 
 suite('Quick Pick Menu Controller', () => {

--- a/docs-markdown/src/test/suite/helper/metadata-completion.test.ts
+++ b/docs-markdown/src/test/suite/helper/metadata-completion.test.ts
@@ -6,6 +6,7 @@ import {
 	CompletionContext,
 	CompletionItem,
 	CompletionItemKind,
+	ExtensionMode,
 	MarkdownString,
 	Position,
 	Range,
@@ -63,7 +64,8 @@ export const context: ExtensionContext = {
 		forEach: () => {},
 		clear: () => {},
 		delete: () => {}
-	}
+	},
+	extensionMode: ExtensionMode.Test
 };
 
 suite('Metadata Provider', () => {

--- a/docs-markdown/src/test/test.common/common.ts
+++ b/docs-markdown/src/test/test.common/common.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'path';
-import { commands, Uri, window, workspace, ExtensionContext } from 'vscode';
+import { commands, Uri, window, workspace, ExtensionContext, ExtensionMode } from 'vscode';
 import { TokenResponse } from '../../helper/Auth';
 
 export const sleepTime = 50;
@@ -75,5 +75,6 @@ export const context: ExtensionContext = {
 		forEach: () => {},
 		clear: () => {},
 		delete: () => {}
-	}
+	},
+	extensionMode: ExtensionMode.Test
 };


### PR DESCRIPTION
This PR fixes the following errors and updates VSCode engine and types to the latest version:

![image](https://user-images.githubusercontent.com/11825888/87835203-4daf8780-c841-11ea-9fd3-5345e3ee9655.png)

