### PR TITLE
Docs-preview release 0.3.53

### DIFF
--- a/docs-preview/changelog.md
+++ b/docs-preview/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.53 (July 20th, 2020)
+
+- Alert bugfix: [Issue 672](https://github.com/microsoft/vscode-docs-authoring/issues/672)
+
 ## 0.3.52 (June 26th, 2020)
 
 - Added clickable links with tilde(~) on preview.

--- a/docs-preview/package-lock.json
+++ b/docs-preview/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "docs-preview",
-	"version": "0.3.52",
+	"version": "0.3.53",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/docs-preview/package.json
+++ b/docs-preview/package.json
@@ -3,7 +3,7 @@
 	"displayName": "docs-preview",
 	"description": "Docs Markdown Preview Extension",
 	"aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-	"version": "0.3.52",
+	"version": "0.3.53",
 	"publisher": "docsmsft",
 	"icon": "images/docs-logo-ms.png",
 	"bugs": {


### PR DESCRIPTION
Release fix for issue [672](https://github.com/microsoft/vscode-docs-authoring/issues/672)