### PR TITLE
Hackathon project - Insert / update Jupyter notebook from GitHub

### DIFF
--- a/docs-markdown/package.json
+++ b/docs-markdown/package.json
@@ -36,6 +36,16 @@
 				"category": "Docs"
 			},
 			{
+				"command": "insertNotebook",
+				"title": "Insert Jupyter notebook",
+				"category": "Docs"
+			},
+			{
+				"command": "updateNotebook",
+				"title": "Update Jupyter notebook",
+				"category": "Docs"
+			},
+			{
 				"command": "markdownQuickPick",
 				"title": "Docs: Markdown authoring menu"
 			},

--- a/docs-markdown/src/controllers/notebook-controller.ts
+++ b/docs-markdown/src/controllers/notebook-controller.ts
@@ -1,0 +1,207 @@
+import * as os from 'os';
+import fetch from 'axios';
+import {
+	insertContentToEditor,
+	findLineNumberOfPattern,
+	noActiveEditorMessage
+} from '../helper/common';
+import { resolve, join } from 'path';
+import { Selection, window, TextEditor } from 'vscode';
+import { spawn, execSync } from 'child_process';
+import { unlinkSync, writeFileSync } from 'fs';
+import { URL } from 'url';
+import { Command } from '../Command';
+
+export const notebookControllerCommands: Command[] = [
+	{ command: insertNotebook.name, callback: insertNotebook },
+	{ command: updateNotebook.name, callback: updateNotebook }
+];
+
+export async function insertNotebook() {
+	const editor = window.activeTextEditor;
+	if (!editor) {
+		noActiveEditorMessage();
+		return;
+	} else {
+		const url = await window.showInputBox({
+			prompt: 'Provide the GitHub URL of the *.ipynb notebook file'
+		});
+
+		if (!url) {
+			window.showInformationMessage('No URL to take action on.');
+			return;
+		}
+
+		const content = await getNotebookAsMarkdown(url);
+		if (content !== null) {
+			insertContentToEditor(editor, content, true);
+		}
+	}
+}
+
+export async function updateNotebook() {
+	const editor = window.activeTextEditor;
+	if (!editor) {
+		noActiveEditorMessage();
+		return;
+	} else {
+		const start = findLineNumberOfPattern(editor, '<!-- nbstart');
+		const end = findLineNumberOfPattern(editor, '<!-- nbend');
+
+		if (start > -1 && end > -1 && start < end) {
+			editor.selection = new Selection(start, 0, end, 14);
+			const url = getUrl(editor, start);
+			const content = await getNotebookAsMarkdown(url);
+			if (content) {
+				insertContentToEditor(editor, content, true);
+			}
+		} else {
+			window.showInformationMessage("There isn't a notebook to update in this document");
+		}
+	}
+}
+
+function getUrl(editor: TextEditor, start: number) {
+	const article = editor.document;
+	const text = article.lineAt(start).text;
+	const url = text.replace('<!-- nbstart ', '').replace(' -->', '');
+
+	return url;
+}
+
+function getConvertPromise(filePath: string) {
+	return new Promise<ConversionResult>((resolve, reject) => {
+		convertToMarkdown(filePath, (result: ConversionResult | null, errorOrNull: Error | null) => {
+			if (errorOrNull || result === null) {
+				reject(errorOrNull);
+			} else {
+				resolve(result);
+			}
+		});
+	});
+}
+
+async function getNotebookAsMarkdown(url: string) {
+	const rawUrl = toRaw(url);
+	const ipynbJson = await getRawNotebookJson(rawUrl);
+	const filePath = 'temp.ipynb';
+	writeFileSync(filePath, ipynbJson);
+	const fullPath = resolve(filePath);
+	try {
+		const result = await getConvertPromise(fullPath);
+		if (result !== null) {
+			return wrapMarkdownInTemplate(result.markdown, rawUrl);
+		}
+
+		return null;
+	} finally {
+		unlinkSync(fullPath);
+	}
+}
+
+async function getRawNotebookJson(url: string): Promise<string> {
+	const response = await fetch(url);
+	const data = await response.data;
+
+	return JSON.stringify(data);
+}
+
+function wrapMarkdownInTemplate(content: string, url: string) {
+	// Advance all the headings by one, avoid multiple H1s
+	content = content.replace(/(^|\r|\n|\r\n)#/g, '\n##');
+
+	const path = toUrl(url);
+	const split = url.split('/');
+	const fileName = split[split.length - 1];
+
+	return (
+		`<!-- nbstart ${url} -->\n\n` +
+		`> [!TIP]\n` +
+		`> Contents of _${fileName}_. **[Open in GitHub](${path})**.\n\n` +
+		`${content}\n` +
+		`<!-- nbend -->\n`
+	);
+}
+
+enum GitHubUrlType {
+	Base,
+	Raw
+}
+
+const blobSegment = 'blob';
+const baseUrl = 'github.com';
+const rawBaseUrl = 'raw.githubusercontent.com';
+
+export const toRaw = (url: string): string => convertUrlTo(url, GitHubUrlType.Raw);
+export const toUrl = (raw: string): string => convertUrlTo(raw, GitHubUrlType.Base);
+
+function convertUrlTo(originalUrl: string, urlType: GitHubUrlType): string {
+	const url = new URL(originalUrl);
+	switch (urlType) {
+		case GitHubUrlType.Base:
+			if (url.hostname === rawBaseUrl) {
+				url.hostname = baseUrl;
+				const segments = url.pathname.split('/');
+				segments.splice(3, 0, blobSegment);
+				url.pathname = segments.join('/');
+			}
+			break;
+		case GitHubUrlType.Raw:
+			if (url.hostname === baseUrl) {
+				url.hostname = rawBaseUrl;
+				const segments = url.pathname.split('/');
+				segments.splice(segments.indexOf(blobSegment), 1);
+				url.pathname = segments.join('/');
+			}
+			break;
+	}
+
+	return url.toString();
+}
+
+interface ConversionResult {
+	markdown: string;
+}
+
+function convertToMarkdown(
+	ipynbPath: string,
+	callback: (result: ConversionResult | null, errorOrNull: Error | null) => void
+) {
+	const args: string[] = [
+		'nbconvert',
+		'--to',
+		'markdown',
+		`"${ipynbPath}"`, // This needs to be wrapped in double quotes
+		'--stdout'
+	];
+
+	let result: ConversionResult | null = null;
+	const plat = os.platform();
+	const stdout = execSync(`${plat === 'win32' ? 'where' : 'which'} python`).toString();
+
+	let pythonPath = stdout.split('\r\n')[0].substr(0, stdout.length - 1);
+	pythonPath = pythonPath.replace('python.exe', '');
+
+	const jupyterPath = join(pythonPath, 'Scripts/jupyter');
+	const path = resolve(jupyterPath);
+	const nbConvert = spawn(path, args, { windowsVerbatimArguments: true });
+
+	nbConvert.stdout.on('data', data => {
+		result = { markdown: data + '' };
+	});
+
+	nbConvert.on('error', err => {
+		callback(null, err);
+	});
+
+	nbConvert.on('exit', (code, _) => {
+		if (code !== 0) {
+			callback(null, {
+				name: 'FileSystemError',
+				message: `Unable to convert '${ipynbPath}' to markdown - error code: ${code}`
+			});
+		} else {
+			callback(result, null);
+		}
+	});
+}

--- a/docs-markdown/src/controllers/notebook-controller.ts
+++ b/docs-markdown/src/controllers/notebook-controller.ts
@@ -107,8 +107,6 @@ async function getRawNotebookJson(url: string): Promise<string> {
 }
 
 function wrapMarkdownInTemplate(content: string, url: string) {
-	// Advance all the headings by one, avoid multiple H1s
-	content = content.replace(/(^|\r|\n|\r\n)#/g, '\n##');
 
 	const path = toUrl(url);
 	const split = url.split('/');

--- a/docs-markdown/src/controllers/quick-pick-menu-controller.ts
+++ b/docs-markdown/src/controllers/quick-pick-menu-controller.ts
@@ -28,6 +28,7 @@ import {
 } from './yaml/yaml-controller';
 import { ExtensionContext } from 'vscode';
 import { Command } from '../Command';
+import { insertNotebook } from './notebook-controller';
 
 export const quickPickMenuCommand: Command[] = [
 	{ command: markdownQuickPick.name, callback: markdownQuickPick }
@@ -41,78 +42,82 @@ export function markdownQuickPick(context: ExtensionContext) {
 
 	if (checkExtension('docsmsft.docs-preview')) {
 		markdownItems.push({
-			description: '',
+			description: 'View preview',
 			label: '$(browser) Preview'
 		});
 		markdownItems.push({
-			description: '',
+			description: 'View search results preview',
 			label: '$(search) Search Results Preview'
 		});
 	}
 
 	markdownItems.push(
 		{
-			description: '',
+			description: 'Bold selected text',
 			label: '$(pencil) Bold'
 		},
 		{
-			description: '',
+			description: 'Italicize selected text',
 			label: '$(info) Italic'
 		},
 		{
-			description: '',
+			description: 'Mark selected text as code block',
 			label: '$(code) Code'
+		},
+		{
+			description: 'Insert a Jupyter notebook from GitHub',
+			label: '$(book) Jupyter Notebook'
 		},
 		{
 			description: 'Insert note, tip, important, caution, or warning',
 			label: '$(alert) Alert'
 		},
 		{
-			description: '',
+			description: 'Insert a numbered list',
 			label: '$(list-ordered) Numbered list'
 		},
 		{
-			description: '',
+			description: 'Insert a bulleted list',
 			label: '$(list-unordered) Bulleted list'
 		},
 		{
-			description: '',
+			description: 'Insert markdown table',
 			label: '$(diff-added) Table'
 		},
 		{
-			description: '',
+			description: 'Insert columns',
 			label: '$(ellipsis) Columns'
 		},
 		{
-			description: '',
+			description: 'Insert link',
 			label: '$(link) Link'
 		},
 		{
-			description: '',
+			description: 'Indicate selected text as non-localizable',
 			label: '$(lock) Non-localizable text'
 		},
 		{
-			description: '',
+			description: 'Insert image',
 			label: '$(file-media) Image'
 		},
 		{
-			description: '',
+			description: 'Insert include file',
 			label: '$(clippy) Include'
 		},
 		{
-			description: '',
+			description: 'Insert code snippet',
 			label: '$(file-code) Snippet'
 		},
 		{
-			description: '',
+			description: 'Insert video',
 			label: '$(device-camera-video) Video'
 		},
 		{
-			description: '',
+			description: 'Perform cleanup',
 			label: '$(tasklist) Cleanup...'
 		},
 		{
-			description: '',
+			description: 'Insert moniker',
 			label: '$(project) Moniker'
 		}
 	);
@@ -193,6 +198,9 @@ export function markdownQuickPick(context: ExtensionContext) {
 				break;
 			case 'code':
 				formatCode();
+				break;
+			case 'jupyter notebook':
+				insertNotebook();
 				break;
 			case 'alert':
 				insertAlert();

--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -110,8 +110,8 @@ export async function activate(context: ExtensionContext) {
 	const authoringCommands: Commands = [
 		...linkControllerCommands,
 		...insertImageCommand,
-    ...quickPickMenuCommand,
-    ...notebookControllerCommands
+		...quickPickMenuCommand,
+		...notebookControllerCommands
 	];
 	insertAlertCommand().forEach(cmd => authoringCommands.push(cmd));
 	insertMonikerCommand().forEach(cmd => authoringCommands.push(cmd));

--- a/docs-markdown/src/extension.ts
+++ b/docs-markdown/src/extension.ts
@@ -75,6 +75,7 @@ import {
 	msTechnologyCompletionItemsProvider,
 	msSubServiceCompletionItemsProvider
 } from './helper/metadata-completion';
+import { notebookControllerCommands } from './controllers/notebook-controller';
 
 export let extensionPath: string;
 type Commands = Command[];
@@ -109,7 +110,8 @@ export async function activate(context: ExtensionContext) {
 	const authoringCommands: Commands = [
 		...linkControllerCommands,
 		...insertImageCommand,
-		...quickPickMenuCommand
+    ...quickPickMenuCommand,
+    ...notebookControllerCommands
 	];
 	insertAlertCommand().forEach(cmd => authoringCommands.push(cmd));
 	insertMonikerCommand().forEach(cmd => authoringCommands.push(cmd));

--- a/docs-markdown/src/helper/common.ts
+++ b/docs-markdown/src/helper/common.ts
@@ -363,5 +363,20 @@ export function toShortDate(date: Date) {
 	const day = date.getDate().toString();
 	const dayStr = day.length > 1 ? day : `0${day}`;
 
-	return `${monthStr}/${dayStr}/${year}`;
+  return `${monthStr}/${dayStr}/${year}`;
+}
+
+export function findLineNumberOfPattern(editor: vscode.TextEditor, pattern: string) {
+	const article = editor.document;
+	let found = -1;
+
+	for (let line = 0; line < article.lineCount; line++) {
+		const text = article.lineAt(line).text;
+		const match = text.match(pattern);
+		if (match !== null && match.index !== undefined) {
+			found = line;
+			return found;
+		}
+	}
+	return found;
 }

--- a/docs-markdown/src/test/suite/controllers/notebook-controller.test.ts
+++ b/docs-markdown/src/test/suite/controllers/notebook-controller.test.ts
@@ -1,0 +1,67 @@
+import * as chai from 'chai';
+import {
+	insertNotebook,
+	updateNotebook,
+	notebookControllerCommands,
+	toRaw,
+	toUrl
+} from '../../../controllers/notebook-controller';
+import { commands } from 'vscode';
+import * as common from '../../../helper/common';
+
+// tslint:disable-next-line: no-var-requires
+const expect = chai.expect;
+
+suite('Notebook Controller', () => {
+	teardown(() => chai.spy.restore(common));
+
+	suiteTeardown(async () => await commands.executeCommand('workbench.action.closeAllEditors'));
+
+	test('notebookControllerCommands', () => {
+		const controllerCommands = [
+			{ command: 'insertNotebook', callback: insertNotebook },
+			{ command: 'updateNotebook', callback: updateNotebook }
+		];
+		expect(notebookControllerCommands).to.deep.equal(controllerCommands);
+	});
+
+	test('insertNotebook shows noActiveEditorMessage', async () => {
+		await commands.executeCommand('workbench.action.closeAllEditors');
+		const spy = chai.spy.on(common, 'noActiveEditorMessage');
+		await insertNotebook();
+		expect(spy).to.have.been.called();
+	});
+
+	test('updateNotebook shows noActiveEditorMessage', async () => {
+		await commands.executeCommand('workbench.action.closeAllEditors');
+		const spy = chai.spy.on(common, 'noActiveEditorMessage');
+		await updateNotebook();
+		expect(spy).to.have.been.called();
+	});
+
+	test('toRaw correctly convert from base URL to raw URL', async () => {
+		const expected =
+			'https://raw.githubusercontent.com/Azure/MachineLearningNotebooks/master/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb';
+
+		expect(
+			toRaw(
+				'https://github.com/Azure/MachineLearningNotebooks/blob/master/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb'
+			)
+		).to.equal(expected);
+
+		expect(toRaw(expected)).to.equal(expected);
+	});
+
+	test('toUrl correctly converts from raw URL to base URL', async () => {
+		const expected =
+			'https://github.com/Azure/MachineLearningNotebooks/blob/master/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb';
+
+		expect(
+			toUrl(
+				'https://raw.githubusercontent.com/Azure/MachineLearningNotebooks/master/tutorials/create-first-ml-experiment/tutorial-1st-experiment-sdk-train.ipynb'
+			)
+		).to.equal(expected);
+
+		expect(toUrl(expected)).to.equal(expected);
+	});
+});


### PR DESCRIPTION
# Show Me the Notebook | Hackathon 2020

Authors: [Sheri Gilley](@sdgilley) & [David Pine](@IEvangelist)

Insert the markdown version of a Jupyter notebook from GitHub into a document.  When the notebook content changes, you can quickly update that markdown.

There are two commands added to the command palette:

* **Docs: Insert Jupyter notebook** - enter the URL of the notebook.  A markdown version of the notebook is added to the document starting at the position of your cursor.  Do not modify the start or end tags; it's what the next function uses to update the notebook.  

* **Docs: Update Jupyter notebook** in the start tag, re-read the notebook and replace the contents between start and end with the latest version.  If you insert multiple notebooks in the same document (why would you do that?) only the first one will be updated.

![showmeInsert](https://user-images.githubusercontent.com/7679720/88833488-efb36600-d197-11ea-8c6c-50c2a39ea41b.gif)

Enjoy!
