### PR TITLE
Fixed issue where SEO preview was not able to pull docfx and breadcrumb file.

### DIFF
--- a/docs-preview/src/helper/common.ts
+++ b/docs-preview/src/helper/common.ts
@@ -92,11 +92,10 @@ export function tryFindFile(rootPath: string, fileName: string) {
 		if (exists) {
 			return fullPath;
 		} else {
-			const files = glob.sync(`**/${fileName}`, {
+			const files = glob.sync(`**/**/${fileName}`, {
 				cwd: rootPath
 			});
-
-			if (files && files.length === 1) {
+			if (files) {
 				return path.join(rootPath, files[0]);
 			}
 		}

--- a/docs-preview/src/seo/seoHelpers.ts
+++ b/docs-preview/src/seo/seoHelpers.ts
@@ -198,38 +198,42 @@ function getRootBreadCrumbs(basePath, filePath) {
 	let matchPath = '';
 	const docFxMetadata = getDocfxMetadata(basePath);
 	let breadCrumbPath = docFxMetadata.build.globalMetadata.breadcrumb_path;
-	if (breadCrumbPath.startsWith('~')) {
-		breadCrumbPath = breadCrumbPath.replace('~', '');
-	}
-	if (breadCrumbPath.startsWith('/azure')) {
-		breadCrumbPath = breadCrumbPath.replace('/azure', '').replace('.json', '.yml');
-	}
-	breadCrumbPath = join(basePath, breadCrumbPath);
-	if (existsSync(breadCrumbPath)) {
-		const pathParts = filePath.split('/');
-		if (pathParts.length > 1) {
-			matchPath = pathParts.slice(1, -1).join('/');
+	if (breadCrumbPath) {
+		if (breadCrumbPath.startsWith('~')) {
+			breadCrumbPath = breadCrumbPath.replace('~', '');
 		}
-		const yamlTOC = readFileSync(breadCrumbPath, 'utf8');
-		const TOC = jsyaml.load(yamlTOC);
-		let breadCrumbs: { breadCrumb: string[]; found: boolean }[] = [{ breadCrumb, found: false }];
-		TOC.forEach(node => {
-			if (node.items && node.items.length > 0) {
-				node.items.forEach((item, index) => {
-					if (!breadCrumbs[index]) {
-						breadCrumbs.push({ breadCrumb: [], found: false });
-					}
-					breadCrumbs[index].breadCrumb.push(node.name);
-					if (item.tocHref.includes(filePath)) {
-						breadCrumbs[index].breadCrumb.push(node.name);
-						breadCrumbs[index].found = true;
-						return;
-					}
-					breadCrumbs = getRootNodes(item, matchPath, breadCrumbs, index);
-				});
+		if (breadCrumbPath.startsWith('/azure')) {
+			breadCrumbPath = breadCrumbPath.replace('/azure', '').replace('.json', '.yml');
+		}
+		breadCrumbPath = join(basePath, breadCrumbPath);
+		if (existsSync(breadCrumbPath)) {
+			const pathParts = filePath.split('/');
+			if (pathParts.length > 1) {
+				matchPath = pathParts.slice(1, -1).join('/');
 			}
-		});
-		breadCrumb = findBreadCrumb(breadCrumbs, breadCrumb);
+			const yamlTOC = readFileSync(breadCrumbPath, 'utf8');
+			const TOC = jsyaml.load(yamlTOC);
+			let breadCrumbs: { breadCrumb: string[]; found: boolean }[] = [{ breadCrumb, found: false }];
+			TOC.forEach(node => {
+				if (node.items && node.items.length > 0) {
+					node.items.forEach((item, index) => {
+						if (!breadCrumbs[index]) {
+							breadCrumbs.push({ breadCrumb: [], found: false });
+						}
+						breadCrumbs[index].breadCrumb.push(node.name);
+						if (item.tocHref.includes(filePath)) {
+							breadCrumbs[index].breadCrumb.push(node.name);
+							breadCrumbs[index].found = true;
+							return;
+						}
+						breadCrumbs = getRootNodes(item, matchPath, breadCrumbs, index);
+					});
+				}
+			});
+			breadCrumb = findBreadCrumb(breadCrumbs, breadCrumb);
+		}
+	} else {
+		breadCrumb.push(basePath.split('/').pop());
 	}
 	return breadCrumb;
 }

--- a/docs-preview/src/seo/seoHelpers.ts
+++ b/docs-preview/src/seo/seoHelpers.ts
@@ -39,7 +39,7 @@ export async function parseMarkdownMetadata(metadata, markdown, basePath, filePa
 	return details;
 }
 
-function checkIfContainsMicrosoftDocs(title) {
+export function checkIfContainsMicrosoftDocs(title) {
 	if (title.includes('| Microsoft Docs')) {
 		return title;
 	} else {
@@ -47,7 +47,7 @@ function checkIfContainsMicrosoftDocs(title) {
 	}
 }
 
-function getMarkdownDescription(
+export function getMarkdownDescription(
 	details: { title: string; description: string; date: string },
 	yamlContent: any,
 	markdown: any
@@ -59,7 +59,7 @@ function getMarkdownDescription(
 	return shortenWithElipsesAtWordEnd(details.description, 305);
 }
 
-async function getTitle(yamlContent: any, title: string, basePath: any, filePath: any) {
+export async function getTitle(yamlContent: any, title: string, basePath: any, filePath: any) {
 	if (yamlContent.titleSuffix) {
 		title = `${yamlContent.title} - ${yamlContent.titleSuffix}`;
 	} else {
@@ -105,7 +105,7 @@ export async function parseYamlMetadata(metadata, breadCrumb, basePath, filePath
 	return details;
 }
 
-function getYamlDescription(yamlContent) {
+export function getYamlDescription(yamlContent) {
 	let description = '';
 	if (yamlContent.title) {
 		description = yamlContent.title;
@@ -136,7 +136,7 @@ function endWithPeriod(content: string) {
 	return content;
 }
 
-function getMainContentIfExists(main: string, alt: string) {
+export function getMainContentIfExists(main: string, alt: string) {
 	if (main) {
 		return main;
 	} else {
@@ -239,7 +239,8 @@ function getRootBreadCrumbs(basePath, filePath) {
 	}
 	return breadCrumb;
 }
-function checkPathEndingWithJson(breadCrumbPath: string) {
+
+export function checkPathEndingWithJson(breadCrumbPath: string) {
 	if (breadCrumbPath.endsWith('json')) {
 		const bcArr = breadCrumbPath.split('.');
 		bcArr.pop();
@@ -249,7 +250,7 @@ function checkPathEndingWithJson(breadCrumbPath: string) {
 	return breadCrumbPath;
 }
 
-function checkStartAndEndPaths(breadCrumbPath: string, basePath: any) {
+export function checkStartAndEndPaths(breadCrumbPath: string, basePath: any) {
 	const bcArr = breadCrumbPath.split('/').filter(val => val);
 	const start = bcArr[0];
 	const end = basePath.split('/').pop();

--- a/docs-preview/src/seo/seoHelpers.ts
+++ b/docs-preview/src/seo/seoHelpers.ts
@@ -205,6 +205,8 @@ function getRootBreadCrumbs(basePath, filePath) {
 		if (breadCrumbPath.startsWith('/azure')) {
 			breadCrumbPath = breadCrumbPath.replace('/azure', '').replace('.json', '.yml');
 		}
+		breadCrumbPath = checkStartAndEndPaths(breadCrumbPath, basePath);
+		breadCrumbPath = checkPathEndingWithJson(breadCrumbPath);
 		breadCrumbPath = join(basePath, breadCrumbPath);
 		if (existsSync(breadCrumbPath)) {
 			const pathParts = filePath.split('/');
@@ -236,6 +238,26 @@ function getRootBreadCrumbs(basePath, filePath) {
 		breadCrumb.push(basePath.split('/').pop());
 	}
 	return breadCrumb;
+}
+function checkPathEndingWithJson(breadCrumbPath: string) {
+	if (breadCrumbPath.endsWith('json')) {
+		const bcArr = breadCrumbPath.split('.');
+		bcArr.pop();
+		bcArr.push('yml');
+		breadCrumbPath = bcArr.join('.');
+	}
+	return breadCrumbPath;
+}
+
+function checkStartAndEndPaths(breadCrumbPath: string, basePath: any) {
+	const bcArr = breadCrumbPath.split('/').filter(val => val);
+	const start = bcArr[0];
+	const end = basePath.split('/').pop();
+	if (start === end) {
+		bcArr.shift();
+		breadCrumbPath = bcArr.join('/');
+	}
+	return breadCrumbPath;
 }
 
 function getRootNodes(
@@ -271,7 +293,7 @@ function getBreadCrumbs(basePath, filePath) {
 		tocPath = join(pathWithoutFileName, '../', 'breadcrumb', 'toc.yml');
 	}
 	tocPath = join(basePath, tocPath);
-	if (existsSync(tocPath)) {
+	if (tocPath && existsSync(tocPath) && (tocPath.endsWith('.yml') || tocPath.endsWith('.md'))) {
 		const yamlTOC = readFileSync(tocPath, 'utf8');
 		const TOC = jsyaml.load(yamlTOC);
 		TOC.forEach(node => {

--- a/docs-preview/src/test/suite/seo/seoHelpers.test.ts
+++ b/docs-preview/src/test/suite/seo/seoHelpers.test.ts
@@ -1,0 +1,102 @@
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+import {
+	getFirstParagraph,
+	checkIfContainsMicrosoftDocs,
+	getMarkdownDescription,
+	getTitle,
+	getYamlDescription,
+	getMainContentIfExists,
+	checkPathEndingWithJson,
+	checkStartAndEndPaths
+} from '../../../seo/seoHelpers';
+
+chai.use(spies);
+
+import sinon = require('sinon');
+
+const expect = chai.expect;
+
+suite('SEO Helper', () => {
+	test('getFirstParagraph', async () => {
+		const markdown = `---
+    author: bharney0
+---
+# Header
+
+first paragraph`;
+		const result = getFirstParagraph(markdown);
+		expect(result).to.be.equal(`first paragraph`);
+	});
+	test('checkIfContainsMicrosoftDocs includes | Microsoft Docs', async () => {
+		const title = `title | Microsoft Docs`;
+		const result = checkIfContainsMicrosoftDocs(title);
+		expect(result).to.be.equal(title);
+	});
+	test('checkIfContainsMicrosoftDocs does not include | Microsoft Docs', async () => {
+		const title = `title`;
+		const result = checkIfContainsMicrosoftDocs(title);
+		expect(result).to.be.equal(`${title} | Microsoft Docs`);
+	});
+	test('getMarkdownDescription', async () => {
+		const detail = {
+			title: '',
+			description: 'description',
+			date: '11/10/2020'
+		};
+		const yamlContent = {
+			description: 'description'
+		};
+		const markdown = `---
+    author: bharney0
+---
+# Header
+
+first paragraph`;
+		const result = getMarkdownDescription(detail, yamlContent, markdown);
+		expect(result).to.be.equal('description');
+	});
+	test('getTitle', async () => {
+		const title = 'title';
+		const yamlContent = {
+			description: 'description',
+			titleSuffix: 'titleSuffix',
+			title: 'title'
+		};
+		const basePath = 'c:/path';
+		const filePath = 'file/path';
+		const result = await getTitle(yamlContent, title, basePath, filePath);
+		expect(result).to.be.equal(`${yamlContent.title} - ${yamlContent.titleSuffix}`);
+	});
+	test('getYamlDescription', async () => {
+		const yamlContent = {
+			summary: 'summary',
+			title: 'title'
+		};
+		const result = getYamlDescription(yamlContent);
+		expect(result).to.be.equal(`${yamlContent.title}. ${yamlContent.summary}.`);
+	});
+	test('getMainContentIfExists content', async () => {
+		const content = 'content';
+		const alt = 'alt';
+		const result = getMainContentIfExists(content, alt);
+		expect(result).to.be.equal(content);
+	});
+	test('getMainContentIfExists alt', async () => {
+		const content = '';
+		const alt = 'alt';
+		const result = getMainContentIfExists(content, alt);
+		expect(result).to.be.equal(alt);
+	});
+	test('checkPathEndingWithJson', async () => {
+		const breadCrumbPath = 'breadcrumb/toc.json';
+		const result = checkPathEndingWithJson(breadCrumbPath);
+		expect(result).to.be.equal('breadcrumb/toc.yml');
+	});
+	test('checkStartAndEndPaths', async () => {
+		const breadCrumbPath = 'path/breadcrumb/toc.yml';
+		const basePath = 'c:/path';
+		const result = checkStartAndEndPaths(breadCrumbPath, basePath);
+		expect(result).to.be.equal('breadcrumb/toc.yml');
+	});
+});


### PR DESCRIPTION
Fixed issue where SEO preview was not able to pull docfx and breadcrumb file.

Issue #679 has been fixed. And tested with referral.md to check if the md file would render the SEO Preview.

Issue had to do with breadcrumb file not being found and terminating the renderer early. Breadcrumb was looking for a yaml file but docfx was pointing to toc.json. Now handling this case. 

[AB#265722](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/265722)