### PR TITLE
Fix links with german characters

### DIFF
--- a/docs-markdown/src/helper/bookmark-builder.ts
+++ b/docs-markdown/src/helper/bookmark-builder.ts
@@ -68,7 +68,7 @@ export function bookmarkBuilder(selectedText: string, bookmarkText: string, path
 	bookmark = bookmarkText
 		.trim()
 		.replace(/\s\s+/g, ' ')
-		.replace(/\n|\r|[^A-Za-z0-9-_\s]/g, '')
+		.replace(/\n|\r|[^A-Za-z0-9-_\säöüÄÖÜß]/g, '')
 		.toLocaleLowerCase()
 		.split(' ')
 		.slice(1)


### PR DESCRIPTION
In germany we have bookmarks which contain german special characters like ä,ö,ü,ß.
These are perfectly fine for markdown or html. But currently these are deleted while generating the link through the "Add Link" Feature. This leads to broken links in our markdown file and currently we fix these broken links manually by adding the characters again.