### PR TITLE
Remove the file I/O from the jupyter notebook, making it more cross-plat

### DIFF
--- a/docs-markdown/src/helper/common.ts
+++ b/docs-markdown/src/helper/common.ts
@@ -34,16 +34,13 @@ export function tryFindFile(rootPath: string, fileName: string) {
 	return undefined;
 }
 
+let osPlatform: string | null = null;
+
 /**
  * Provide current os platform
  */
-export function getOSPlatform(this: any) {
-	if (this.osPlatform == null) {
-		this.osPlatform = os.platform();
-		this.osPlatform = this.osPlatform;
-	}
-	return this.osPlatform;
-}
+export const getOSPlatform = () =>
+	osPlatform === null ? (osPlatform = os.platform()) : osPlatform;
 
 /**
  * Create a posted warning message and applies the message to the log
@@ -363,7 +360,7 @@ export function toShortDate(date: Date) {
 	const day = date.getDate().toString();
 	const dayStr = day.length > 1 ? day : `0${day}`;
 
-  return `${monthStr}/${dayStr}/${year}`;
+	return `${monthStr}/${dayStr}/${year}`;
 }
 
 export function findLineNumberOfPattern(editor: vscode.TextEditor, pattern: string) {

--- a/docs-markdown/src/test/suite/controllers/media-controller.test.ts
+++ b/docs-markdown/src/test/suite/controllers/media-controller.test.ts
@@ -63,13 +63,13 @@ suite('Media Controller', () => {
 				'https://channel9.msdn.com/Series/Youve-Got-Key-Values-A-Redis-Jump-Start/03/player'
 			);
 		const stubWorkspaceConfiguration = sinon.stub(workspace, 'getConfiguration').returns({
-				get: () => false,
-				has: () => true,
-				inspect: () => {
-					return { key: '' };
-				},
-				update: () => Promise.resolve()
-			});
+			get: () => false,
+			has: () => true,
+			inspect: () => {
+				return { key: '' };
+			},
+			update: () => Promise.resolve()
+		});
 		const filePath = resolve(
 			__dirname,
 			'../../../../../src/test/data/repo/articles/media-controller.md'
@@ -91,14 +91,14 @@ suite('Media Controller', () => {
 			.resolves(
 				'https://channel9.msdn.com/Series/Youve-Got-Key-Values-A-Redis-Jump-Start/03/player'
 			);
-			const stubWorkspaceConfiguration = sinon.stub(workspace, 'getConfiguration').returns({
-				get: () => true,
-				has: () => true,
-				inspect: () => {
-					return { key: '' };
-				},
-				update: () => Promise.resolve()
-			});
+		const stubWorkspaceConfiguration = sinon.stub(workspace, 'getConfiguration').returns({
+			get: () => true,
+			has: () => true,
+			inspect: () => {
+				return { key: '' };
+			},
+			update: () => Promise.resolve()
+		});
 		const filePath = resolve(
 			__dirname,
 			'../../../../../src/test/data/repo/articles/media-controller1.md'

--- a/docs-markdown/src/test/suite/controllers/quick-pick-menu-controller.test.ts
+++ b/docs-markdown/src/test/suite/controllers/quick-pick-menu-controller.test.ts
@@ -83,12 +83,12 @@ suite('Quick Pick Menu Controller', () => {
 	suiteSetup(() => {
 		sinon.stub(telemetry, 'sendTelemetryData');
 		sinon.stub(workspace, 'getConfiguration').returns({
-				get: () => true,
-				has: () => true,
-				inspect: () => {
-					return { key: '' };
-				},
-				update: () => Promise.resolve()
+			get: () => true,
+			has: () => true,
+			inspect: () => {
+				return { key: '' };
+			},
+			update: () => Promise.resolve()
 		});
 	});
 	suiteTeardown(async () => {

--- a/docs-markdown/src/test/suite/helper/utility.test.ts
+++ b/docs-markdown/src/test/suite/helper/utility.test.ts
@@ -23,13 +23,13 @@ suite('Utility helper class', () => {
 	});
 	test('videoLinkBuilder returns triple colon video', () => {
 		const stubWorkspaceConfiguration = sinon.stub(workspace, 'getConfiguration').returns({
-				get: () => true,
-				has: () => true,
-				inspect: () => {
-					return { key: '' };
-				},
-				update: () => Promise.resolve()
-			});
+			get: () => true,
+			has: () => true,
+			inspect: () => {
+				return { key: '' };
+			},
+			update: () => Promise.resolve()
+		});
 		const videoLink = utility.videoLinkBuilder(
 			'https://channel9.msdn.com/Series/Youve-Got-Key-Values-A-Redis-Jump-Start/03/player'
 		);


### PR DESCRIPTION
Remove file I/O of Jupyter notebook, and instead leverage the JSON in memory - passing it as `stdin` to nbcovert.

/cc @sdgilley 