### PR TITLE
Remove output channel from common

### DIFF
--- a/docs-preview/src/helper/common.ts
+++ b/docs-preview/src/helper/common.ts
@@ -5,7 +5,6 @@ import * as glob from 'glob';
 import * as path from 'path';
 import { TextDocument, Uri, window, workspace, Position, commands } from 'vscode';
 import { reporter } from './telemetry';
-export const output = window.createOutputChannel('docs-preview');
 
 /**
  * Create a posted warning message and applies the message to the log

--- a/docs-preview/src/markdown-extensions/column.ts
+++ b/docs-preview/src/markdown-extensions/column.ts
@@ -1,4 +1,4 @@
-import { output } from '../helper/common';
+import { output } from '../extension';
 
 export const columnOptions = {
 	marker: ':',

--- a/docs-preview/src/markdown-extensions/image.ts
+++ b/docs-preview/src/markdown-extensions/image.ts
@@ -1,4 +1,4 @@
-import { output } from '../helper/common';
+import { output } from '../extension';
 
 const IMAGE_OPEN_RE = /image\s+(((source|type|alt-text|lightbox|border|loc-scope|link)="(.*?))"\s*)+:::/gm;
 

--- a/docs-preview/src/markdown-extensions/includes.ts
+++ b/docs-preview/src/markdown-extensions/includes.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { basename, resolve } from 'path';
 import { window, workspace } from 'vscode';
-import { output } from '../helper/common';
+import { output } from '../extension';
 
 /* tslint:disable: no-conditional-assignment */
 const INCLUDE_RE = /\[!include\s*\[\s*.+?\s*]\(\s*(.+?)\s*\)\s*]/i;

--- a/docs-preview/src/markdown-extensions/rootDirectory.ts
+++ b/docs-preview/src/markdown-extensions/rootDirectory.ts
@@ -1,5 +1,5 @@
 import { workspace } from 'vscode';
-import { output } from '../helper/common';
+import { output } from '../extension';
 import * as os from 'os';
 
 const LINK_RE = /(\[.*?\]\()(.*~.*?)(\))/g;

--- a/docs-preview/src/markdown-extensions/xref.ts
+++ b/docs-preview/src/markdown-extensions/xref.ts
@@ -1,6 +1,6 @@
 import Axios from 'axios';
 import { commands } from 'vscode';
-import { output } from '../helper/common';
+import { output } from '../extension';
 
 /* tslint:disable: no-conditional-assignment */
 


### PR DESCRIPTION
Docs-preview is creating multiple output channels.  We only need the channel created in extension.ts so this PR removes the additional channel spun up in common.ts.

![image](https://user-images.githubusercontent.com/11825888/89449307-bc2f8900-d70d-11ea-9dfe-3cac83661c69.png)
