### PR TITLE
Added image extension for inline blocks

### DIFF
--- a/docs-preview/src/extension.ts
+++ b/docs-preview/src/extension.ts
@@ -9,7 +9,7 @@ import { codeSnippets, tripleColonCodeSnippets } from './markdown-extensions/cod
 import { column_end, columnEndOptions, columnOptions } from './markdown-extensions/column';
 import { container_plugin } from './markdown-extensions/container';
 import { div_plugin, divOptions } from './markdown-extensions/div';
-import { image_end, imageOptions } from './markdown-extensions/image';
+import { image_end, imageOptions, image_plugin } from './markdown-extensions/image';
 import { include } from './markdown-extensions/includes';
 import { rowEndOptions, rowOptions } from './markdown-extensions/row';
 import { videoOptions, legacyVideoOptions } from './markdown-extensions/video';
@@ -86,7 +86,7 @@ export async function activate(context: ExtensionContext) {
 				.use(container_plugin, 'column', columnOptions)
 				.use(container_plugin, 'column-end', columnEndOptions)
 				.use(div_plugin, 'div', divOptions)
-				.use(container_plugin, 'image', imageOptions)
+				.use(image_plugin, 'image', imageOptions)
 				.use(image_end)
 				.use(container_plugin, 'video', videoOptions)
 				.use(container_plugin, 'legacyVideo', legacyVideoOptions)

--- a/docs-preview/src/extension.ts
+++ b/docs-preview/src/extension.ts
@@ -3,7 +3,7 @@
 import { appendFileSync, readFileSync, writeFileSync } from 'fs';
 import { basename, join } from 'path';
 import { commands, ExtensionContext, ViewColumn, WebviewPanel, window, workspace } from 'vscode';
-import { isMarkdownFile, isYamlFile, sendTelemetryData } from './helper/common';
+import { isMarkdownFile, isYamlFile, sendTelemetryData, output } from './helper/common';
 import { Reporter } from './helper/telemetry';
 import { codeSnippets, tripleColonCodeSnippets } from './markdown-extensions/codesnippet';
 import { column_end, columnEndOptions, columnOptions } from './markdown-extensions/column';
@@ -17,7 +17,6 @@ import { DocumentContentProvider } from './seo/seoPreview';
 import { xref } from './markdown-extensions/xref';
 import { rootDirectory } from './markdown-extensions/rootDirectory';
 
-export const output = window.createOutputChannel('docs-preview');
 export let extensionPath: string;
 const telemetryCommand: string = 'preview';
 

--- a/docs-preview/src/helper/common.ts
+++ b/docs-preview/src/helper/common.ts
@@ -6,6 +6,8 @@ import * as path from 'path';
 import { TextDocument, Uri, window, workspace, Position, commands } from 'vscode';
 import { reporter } from './telemetry';
 
+export const output = window.createOutputChannel('docs-preview');
+
 /**
  * Create a posted warning message and applies the message to the log
  * @param {string} message - the message to post to the editor as an warning.

--- a/docs-preview/src/markdown-extensions/codesnippet.ts
+++ b/docs-preview/src/markdown-extensions/codesnippet.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import { Base64 } from 'js-base64';
 import { parse, resolve } from 'path';
 import { workspace, commands } from 'vscode';
-import { output } from '../extension';
+import { output } from '../helper/common';
 
 // async fs does not have import module available
 const fs = require('fs');

--- a/docs-preview/src/markdown-extensions/column.ts
+++ b/docs-preview/src/markdown-extensions/column.ts
@@ -1,4 +1,4 @@
-import { output } from '../extension';
+import { output } from '../helper/common';
 
 export const columnOptions = {
 	marker: ':',

--- a/docs-preview/src/markdown-extensions/image.ts
+++ b/docs-preview/src/markdown-extensions/image.ts
@@ -1,6 +1,6 @@
-import { output } from '../extension';
+import { output } from '../helper/common';
 
-const IMAGE_OPEN_RE = /image\s+(((source|type|alt-text|lightbox|border|loc-scope|link)="(.*?))"\s*)+:::/gm;
+const IMAGE_OPEN_RE = /:::image\s+(((source|type|alt-text|lightbox|border|loc-scope|link)="(.*?))"\s*)+:::/;
 
 export const imageOptions = {
 	marker: ':',

--- a/docs-preview/src/markdown-extensions/image.ts
+++ b/docs-preview/src/markdown-extensions/image.ts
@@ -81,3 +81,51 @@ export function image_end(md) {
 	};
 	md.core.ruler.before('normalize', 'imageclose', importImageEnd);
 }
+
+/* tslint:disable: one-variable-per-declaration prefer-const variable-name */
+
+export function image_plugin(md, name, options) {
+	options = options || {};
+	const marker_str = options.marker;
+	const render = options.render;
+	const tripleColon = ':::';
+	function imageContainer(state, silent) {
+		let pos = state.pos;
+		if (state.src.charAt(pos) !== marker_str) {
+			return false;
+		}
+		pos++;
+		if (state.src.charAt(pos) !== marker_str) {
+			return false;
+		}
+		pos++;
+		if (state.src.charAt(pos) !== marker_str) {
+			return false;
+		}
+		pos++;
+		const markup = state.src.slice(state.pos, pos);
+
+		const endOfContainer = state.src.indexOf(tripleColon, pos);
+		if (endOfContainer !== -1) {
+			const params = state.src.slice(state.pos, endOfContainer + 3);
+
+			if (!silent) {
+				const token = state.push(`${name}_container`, 'img', 0);
+				token.info = params;
+			}
+			state.pos = endOfContainer + 3;
+			return true;
+		}
+
+		if (!silent) {
+			state.pending += markup;
+		}
+		state.pos = pos;
+		return true;
+	}
+
+	md.inline.ruler.push(`${name}_container`, imageContainer, {
+		alt: []
+	});
+	md.renderer.rules[`${name}_container`] = render;
+}

--- a/docs-preview/src/markdown-extensions/includes.ts
+++ b/docs-preview/src/markdown-extensions/includes.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { basename, resolve } from 'path';
 import { window, workspace } from 'vscode';
-import { output } from '../extension';
+import { output } from '../helper/common';
 
 /* tslint:disable: no-conditional-assignment */
 const INCLUDE_RE = /\[!include\s*\[\s*.+?\s*]\(\s*(.+?)\s*\)\s*]/i;

--- a/docs-preview/src/markdown-extensions/rootDirectory.ts
+++ b/docs-preview/src/markdown-extensions/rootDirectory.ts
@@ -1,5 +1,5 @@
 import { workspace } from 'vscode';
-import { output } from '../extension';
+import { output } from '../helper/common';
 import * as os from 'os';
 
 const LINK_RE = /(\[.*?\]\()(.*~.*?)(\))/g;

--- a/docs-preview/src/markdown-extensions/xref.ts
+++ b/docs-preview/src/markdown-extensions/xref.ts
@@ -1,6 +1,6 @@
 import Axios from 'axios';
 import { commands } from 'vscode';
-import { output } from '../extension';
+import { output } from '../helper/common';
 
 /* tslint:disable: no-conditional-assignment */
 

--- a/docs-preview/src/test/suite/markdown-extensions/image.test.ts
+++ b/docs-preview/src/test/suite/markdown-extensions/image.test.ts
@@ -1,42 +1,41 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import * as chai from 'chai';
-import { container_plugin } from '../../../markdown-extensions/container';
-import { image_end, imageOptions } from '../../../markdown-extensions/image';
+import { image_end, imageOptions, image_plugin } from '../../../markdown-extensions/image';
 const expect = chai.expect;
 
 suite('Image Extension', () => {
-	const md = require('markdown-it')().use(container_plugin, 'image', imageOptions).use(image_end);
+	const md = require('markdown-it')().use(image_plugin, 'image', imageOptions).use(image_end);
 	test('Image type content', async () => {
 		const result = md.render(
 			`:::image type="content" source="../links/media/LSIs.png" alt-text="lsi":::`
 		);
 		expect(result).to.equal(
-			`<div class="mx-imgBorder"><p><img src="../links/media/LSIs.png"></p></div>`
+			`<p><div class="mx-imgBorder"><p><img src="../links/media/LSIs.png"></p></div></p>\n`
 		);
 	});
 	test('Image type icon', async () => {
 		const result = md.render(`:::image type="icon" source="../links/media/LSIs.png":::`);
-		expect(result).to.equal(`<img src="../links/media/LSIs.png">`);
+		expect(result).to.equal(`<p><img src="../links/media/LSIs.png"></p>\n`);
 	});
 	test('Image type complex', async () => {
 		const result = md.render(`:::image type="complex" source="../links/media/LSIs.png" alt-text="lsi complex":::
         :::image-end:::`);
 		expect(result).to.equal(
-			`<div class="mx-imgBorder"><p><img src="../links/media/LSIs.png"></p></div>`
+			`<p><div class="mx-imgBorder"><p><img src="../links/media/LSIs.png"></p></div></p>\n`
 		);
 	});
 	test('Image type content - no border', async () => {
 		const result = md.render(
 			`:::image type="content" source="../links/media/LSIs.png" border="false" alt-text="lsi":::`
 		);
-		expect(result).to.equal(`<img src="../links/media/LSIs.png">`);
+		expect(result).to.equal(`<p><img src="../links/media/LSIs.png"></p>\n`);
 	});
 	test('Image type content - lightbox', async () => {
 		const result = md.render(
 			`:::image type="content" source="../links/media/LSIs.png" lightbox="../links/media/LSIs.png" alt-text="lsi":::`
 		);
 		expect(result).to.equal(
-			`<a href="../links/media/LSIs.png#lightbox" data-linktype="relative-path"><div class="mx-imgBorder"><p><img src="../links/media/LSIs.png"></p></div></a>`
+			`<p><a href="../links/media/LSIs.png#lightbox" data-linktype="relative-path"><div class="mx-imgBorder"><p><img src="../links/media/LSIs.png"></p></div></a></p>\n`
 		);
 	});
 	test('Image type content - link', async () => {
@@ -44,7 +43,7 @@ suite('Image Extension', () => {
 			`:::image type="content" source="../links/media/LSIs.png" alt-text="lsi" link="https://microsoft.com":::`
 		);
 		expect(result).to.equal(
-			`<a href="https://microsoft.com" data-linktype="relative-path"><div class="mx-imgBorder"><p><img src="../links/media/LSIs.png"></p></div></a>`
+			`<p><a href="https://microsoft.com" data-linktype="relative-path"><div class="mx-imgBorder"><p><img src="../links/media/LSIs.png"></p></div></a></p>\n`
 		);
 	});
 });


### PR DESCRIPTION
Added image extension for inline blocks. Triple Colon Images now work inline with other text and render fine without having their own line. [AB#272927](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/272927)
![image](https://user-images.githubusercontent.com/51799435/90057180-e399cf00-dc94-11ea-944f-13b7e90f956b.png)
