### PR TITLE
Adding wrapper.js

### DIFF
--- a/packages/docs-preview/media/wrapper.js
+++ b/packages/docs-preview/media/wrapper.js
@@ -1,0 +1,14 @@
+var body = document.getElementsByClassName('vscode-body')[0];
+
+var mainContainer = document.createElement('div');
+mainContainer.classList.add('content');
+mainContainer.classList.add('has-top-padding');
+mainContainer.classList.add('uhf-container');
+// Move the body's children into this wrapper
+while (body.firstChild) {
+	mainContainer.appendChild(body.firstChild);
+}
+
+// Append the wrapper to the body
+document.body.appendChild(mainContainer);
+body.setAttribute('class', 'theme-light');


### PR DESCRIPTION
Wrapper.js is ignored so it doesn't look like it moved with the husky changes.

Here's an older [branch](https://github.com/microsoft/vscode-docs-authoring/tree/279111_AllowlistProxy/docs-preview/media) with wrapper.js for reference.