### PR TITLE
Setup docs-authoring-pack as extensionPack

### DIFF
--- a/packages/docs-authoring-pack/package.json
+++ b/packages/docs-authoring-pack/package.json
@@ -3,7 +3,7 @@
   "displayName": "Docs Authoring Pack",
   "description": "Collection of extensions to assist with content development for docs.microsoft.com",
   "icon": "images/docs-logo-ms.png",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "publisher": "docsmsft",
   "engines": {
     "vscode": "^1.20.0"
@@ -20,6 +20,18 @@
   ],
   "keywords": [
     "markdown"
+  ],
+  "extensionPack": [
+    "DavidAnson.vscode-markdownlint",
+    "docsmsft.docs-images",
+    "docsmsft.docs-preview",
+    "docsmsft.docs-markdown",
+    "docsmsft.docs-linting",
+    "docsmsft.docs-article-templates",
+    "streetsidesoftware.code-spell-checker",
+    "docsmsft.docs-yaml",
+    "docsmsft.docs-metadata",
+    "blackmist.LinkCheckMD"
   ],
   "extensionDependencies": [
     "DavidAnson.vscode-markdownlint",


### PR DESCRIPTION
Added extension pack config.
```
 "extensionPack": [
    "DavidAnson.vscode-markdownlint",
    "docsmsft.docs-images",
    "docsmsft.docs-preview",
    "docsmsft.docs-markdown",
    "docsmsft.docs-linting",
    "docsmsft.docs-article-templates",
    "streetsidesoftware.code-spell-checker",
    "docsmsft.docs-yaml",
    "docsmsft.docs-metadata",
    "blackmist.LinkCheckMD"
  ],
```