### PR TITLE
docs-markdown production release version 0.2.81

### DIFF
--- a/packages/docs-markdown/changelog.md
+++ b/packages/docs-markdown/changelog.md
@@ -3,10 +3,13 @@
 ## 0.2.81 (September 29th, 2020)
 
 - Validation extension integration.
+- Updated devlangs to include X++.
+- Removed quick pick command descriptions.
+- Added no-loc unit tests.
 
 ## 0.2.80 (August 18th, 2020)
 
-- Added :::code::: to triple colon auto-complete.
+- Added `:::code:::` to triple colon auto-complete.
 
 ## 0.2.79 (August 12th, 2020)
 

--- a/packages/docs-markdown/package.json
+++ b/packages/docs-markdown/package.json
@@ -784,7 +784,7 @@
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^12.12.32",
 		"@types/recursive-readdir": "^2.2.0",
-		"@types/vscode": "^1.47.0",
+		"@types/vscode": "^1.49.0",
 		"@types/yamljs": "^0.2.30",
 		"@typescript-eslint/eslint-plugin": "^2.34.0",
 		"@typescript-eslint/eslint-plugin-tslint": "^2.34.0",

--- a/packages/docs-markdown/package.json
+++ b/packages/docs-markdown/package.json
@@ -4,7 +4,7 @@
 	"description": "Docs Markdown Extension",
 	"icon": "images/docs-logo-ms.png",
 	"aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-	"version": "0.2.80",
+	"version": "0.2.81",
 	"publisher": "docsmsft",
 	"homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
 	"bugs": {

--- a/packages/docs-markdown/package.json
+++ b/packages/docs-markdown/package.json
@@ -784,7 +784,7 @@
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^12.12.32",
 		"@types/recursive-readdir": "^2.2.0",
-		"@types/vscode": "^1.49.0",
+		"@types/vscode": "^1.47.0",
 		"@types/yamljs": "^0.2.30",
 		"@typescript-eslint/eslint-plugin": "^2.34.0",
 		"@typescript-eslint/eslint-plugin-tslint": "^2.34.0",


### PR DESCRIPTION
Changes for docs-markdown release 0.2.81 include:
- Validation extension integration.
- Updated devlangs to include X++.
- Removed quick pick command descriptions.
- Added no-loc unit tests.