### PR TITLE
Fix broken Preview image link after repo reorg

### DIFF
--- a/packages/docs-preview/README.md
+++ b/packages/docs-preview/README.md
@@ -21,7 +21,7 @@ NEW: Docs Preview now also includes Search Results Preview, which uses publicly 
 
 The docs-preview extension supports light, dark and high contrast themes.  You can select a default theme by going to File => Preferences => Settings => Extensions => Docs Preview Extension Configuration and choosing a theme.  A toast notification will show after a theme is selected to prompt the user to reload the VS Code for the settings to take effect.
 
-![Preview setting](https://raw.githubusercontent.com/microsoft/vscode-docs-authoring/master/docs-preview/images/preview-setting.gif)
+![Preview setting](https://raw.githubusercontent.com/microsoft/vscode-docs-authoring/master/packages/docs-preview/images/preview-setting.gif)
 
 If you also have the [Docs Markdown](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-markdown) extension installed, you can access preview from the Docs Markdown menu:
 


### PR DESCRIPTION
Preview setting image didn't appear because link was broken. Previous link contained the "full path" (https://raw.githubusercontent...) so I kept it that way, probably needed while rendered on MS Marketplace and places like that.  

Very nice package BTW! 👍