### PR TITLE
Fixed issue where metadata date nag is prompting markdown message when saving on all documents

### DIFF
--- a/packages/docs-markdown/src/controllers/metadata-controller.ts
+++ b/packages/docs-markdown/src/controllers/metadata-controller.ts
@@ -9,7 +9,8 @@ import {
 	isMarkdownFileCheck,
 	noActiveEditorMessage,
 	tryFindFile,
-	toShortDate
+	toShortDate,
+	isMarkdownYamlFileCheckWithoutNotification
 } from '../helper/common';
 import { sendTelemetryData } from '../helper/telemetry';
 import { applyReplacements, findReplacement, Replacements } from '../helper/utility';
@@ -215,7 +216,7 @@ export async function updateMetadataDate() {
 		return;
 	}
 
-	if (!isMarkdownFileCheck(editor, false)) {
+	if (!isMarkdownYamlFileCheckWithoutNotification(editor)) {
 		return;
 	}
 

--- a/packages/docs-markdown/src/helper/common.ts
+++ b/packages/docs-markdown/src/helper/common.ts
@@ -235,6 +235,14 @@ export function isMarkdownFileCheckWithoutNotification(editor: vscode.TextEditor
 	}
 }
 
+export function isMarkdownYamlFileCheckWithoutNotification(editor: vscode.TextEditor) {
+	if (editor.document.languageId === 'markdown' || editor.document.languageId === 'yaml') {
+		return true;
+	} else {
+		return false;
+	}
+}
+
 export function isValidFileCheck(editor: vscode.TextEditor, languageIds: string[]) {
 	return languageIds.some(id => editor.document.languageId === id);
 }

--- a/packages/docs-markdown/src/helper/metadata.ts
+++ b/packages/docs-markdown/src/helper/metadata.ts
@@ -1,6 +1,10 @@
 import { updateMetadataDate } from '../controllers/metadata-controller';
 import { workspace, window, Position, Range } from 'vscode';
-import { noActiveEditorMessage, toShortDate, isMarkdownFileCheck } from './common';
+import {
+	noActiveEditorMessage,
+	toShortDate,
+	isMarkdownYamlFileCheckWithoutNotification
+} from './common';
 import { findReplacement } from './utility';
 
 const blacklist: string[] = [];
@@ -19,7 +23,7 @@ export async function metadataDateReminder() {
 		return;
 	}
 
-	if (!isMarkdownFileCheck(editor, false)) {
+	if (!isMarkdownYamlFileCheckWithoutNotification(editor)) {
 		return;
 	}
 

--- a/packages/docs-markdown/src/test/suite/controllers/metadata-controller.test.ts
+++ b/packages/docs-markdown/src/test/suite/controllers/metadata-controller.test.ts
@@ -98,12 +98,12 @@ suite('Metadata Controller', () => {
 		metadataController.updateMetadataDate();
 		expect(spy).to.have.been.called();
 	});
-	test('updateMetadataDate().isMarkdownFileCheck()', async () => {
+	test('updateMetadataDate().isMarkdownYamlFileCheckWithoutNotification()', async () => {
 		// pass in a non-markdown file
 		const filePath = resolve(__dirname, '../../../../../src/test/data/repo/docfx.json');
 		await loadDocumentAndGetItReady(filePath);
 
-		const spy = chai.spy.on(common, 'isMarkdownFileCheck');
+		const spy = chai.spy.on(common, 'isMarkdownYamlFileCheckWithoutNotification');
 		await metadataController.updateMetadataDate();
 		expect(spy).to.have.been.called();
 	});


### PR DESCRIPTION
Issue where metadata date nag was notifying users that command only works on markdown document fixed to no longer notify users.