### PR TITLE
docs-markdown release 0.2.84

### DIFF
--- a/packages/docs-markdown/changelog.md
+++ b/packages/docs-markdown/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.84 (February 24th, 2021)
+
+- Bug fixe for metadata date nag and add period to alt text.
+
 ## 0.2.83 (February 24th, 2021)
 
 - Bug fixes

--- a/packages/docs-markdown/changelog.md
+++ b/packages/docs-markdown/changelog.md
@@ -1,8 +1,8 @@
 # Change Log
 
-## 0.2.84 (February 24th, 2021)
+## 0.2.84 (March 1st, 2021)
 
-- Bug fixe for metadata date nag and add period to alt text.
+- Bug fixes for metadata date nag and add period to alt text.
 
 ## 0.2.83 (February 24th, 2021)
 

--- a/packages/docs-markdown/package.json
+++ b/packages/docs-markdown/package.json
@@ -4,7 +4,7 @@
 	"description": "Docs Markdown Extension",
 	"icon": "images/docs-logo-ms.png",
 	"aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-	"version": "0.2.83",
+	"version": "0.2.84",
 	"publisher": "docsmsft",
 	"homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
 	"bugs": {


### PR DESCRIPTION
- Fixed bug with add period to alt text not running on cleanup
- Fixed bug with metadata date nag running on all files and notifying user that command only works on markdown file