### PR TITLE
Support content subsets defined in docfx.json

### DIFF
--- a/packages/docs-markdown/src/controllers/links/linkToDocsPageByUrl.ts
+++ b/packages/docs-markdown/src/controllers/links/linkToDocsPageByUrl.ts
@@ -119,23 +119,31 @@ async function getLocalRepoFileLink(
 function UrlInCurrentContentSet(content: DocFxContent, metadata, editor) {
 	if (content.build && content.build.content) {
 		const currentFilePath = editor.document.uri.fsPath;
-		const currentPathFolders = currentFilePath.split('/');
+		const currentPathFolders = currentFilePath.replace(/\\/g, '/').split('/');
 		const contentArr = content.build.content;
 		const linkPathFolders = metadata.split('/');
 		let bothMatch = false;
-		contentArr.forEach(file => {
-			let match = false;
-			linkPathFolders.forEach(folder => {
-				if (file.src === folder) {
-					match = true;
+		let match = '';
+		for (const file of contentArr) {
+			if (file.src) {
+				for (const linkPathFolder of linkPathFolders) {
+					if (file.src === linkPathFolder) {
+						match = file.src;
+						break;
+					}
 				}
-			});
-			currentPathFolders.forEach(folder => {
-				if (file.src === folder && match) {
-					bothMatch = true;
+				for (const currentPathFolder of currentPathFolders) {
+					if (file.src === currentPathFolder && match === currentPathFolder) {
+						bothMatch = true;
+						break;
+					}
 				}
-			});
-		});
+				if (bothMatch) {
+					break;
+				}
+			}
+		}
+
 		return bothMatch;
 	}
 	return true;

--- a/packages/docs-markdown/src/controllers/links/linkToDocsPageByUrl.ts
+++ b/packages/docs-markdown/src/controllers/links/linkToDocsPageByUrl.ts
@@ -107,8 +107,12 @@ async function getLocalRepoFileLink(
 			const repoName = folderPath.split('\\').pop();
 			if (checkIfUrlRepoIsInCurrentRepo(metadata, repoName)) {
 				const content = getDocfxContent(editor);
-				if (content && UrlInCurrentContentSet(content, metadata, editor)) {
+				if (!content) {
 					return buildRelativePathBasedOnMetadata(metadata, folderPath, editor, altText);
+				} else {
+					if (UrlInCurrentContentSet(content, metadata, editor)) {
+						return buildRelativePathBasedOnMetadata(metadata, folderPath, editor, altText);
+					}
 				}
 			}
 		}

--- a/packages/docs-markdown/src/controllers/links/linkToDocsPageByUrl.ts
+++ b/packages/docs-markdown/src/controllers/links/linkToDocsPageByUrl.ts
@@ -107,13 +107,16 @@ async function getLocalRepoFileLink(
 			const repoName = folderPath.split('\\').pop();
 			if (checkIfUrlRepoIsInCurrentRepo(metadata, repoName)) {
 				const content = getDocfxContent(editor);
-				if (!content) {
-					return buildRelativePathBasedOnMetadata(metadata, folderPath, editor, altText);
-				} else {
-					if (UrlInCurrentContentSet(content, metadata, editor)) {
-						return buildRelativePathBasedOnMetadata(metadata, folderPath, editor, altText);
+				if (
+					content &&
+					content.build &&
+					content.build.content &&
+					content.build.content.some(file => file.src)
+				)
+					if (!UrlInCurrentContentSet(content, metadata, editor)) {
+						return { confirmation: '', link: '' };
 					}
-				}
+				return buildRelativePathBasedOnMetadata(metadata, folderPath, editor, altText);
 			}
 		}
 	}

--- a/packages/docs-markdown/src/test/suite/controllers/cleanup/cleanup-controller.test.ts
+++ b/packages/docs-markdown/src/test/suite/controllers/cleanup/cleanup-controller.test.ts
@@ -131,8 +131,8 @@ suite('Cleanup Controller', () => {
 		const spy = chai.spy.on(removeEmptyMetadata, 'removeEmptyMetadata');
 		await applyCleanup();
 		await sleep(extendedSleepTime);
-		mockShowQuickPick.restore();
 		expect(spy).to.have.been.called();
+		mockShowQuickPick.restore();
 	});
 	test('cleanup repo - empty metadata - n/a', async () => {
 		await loadDocumentAndGetItReady(filePath);

--- a/packages/docs-markdown/src/test/suite/controllers/image-controller.test.ts
+++ b/packages/docs-markdown/src/test/suite/controllers/image-controller.test.ts
@@ -18,7 +18,12 @@ import {
 } from '../../../controllers/image-controller';
 import * as common from '../../../helper/common';
 import * as telemetry from '../../../helper/telemetry';
-import { loadDocumentAndGetItReady, sleep, extendedSleepTime } from '../../test.common/common';
+import {
+	loadDocumentAndGetItReady,
+	sleep,
+	extendedSleepTime,
+	longSleepTime
+} from '../../test.common/common';
 import { context } from '../../test.common/common';
 
 chai.use(spies);
@@ -104,7 +109,7 @@ suite('Image Controller', () => {
 		const expectedText = ':::image type="content" source="../images/test.png" alt-text="foo":::';
 		const editor = window.activeTextEditor;
 		const actualText = editor?.document.getText();
-		await sleep(extendedSleepTime);
+		await sleep(longSleepTime);
 		assert.equal(expectedText, actualText);
 		stubShowQuickPick.restore();
 		stubShowInputBox.restore();
@@ -130,7 +135,6 @@ suite('Image Controller', () => {
 
 		await loadDocumentAndGetItReady(filePath);
 		await pickImageType(context);
-		await sleep(extendedSleepTime);
 		const expectedText =
 			':::image type="complex" source="../images/test.png" alt-text="foo":::' +
 			os.EOL +
@@ -138,6 +142,7 @@ suite('Image Controller', () => {
 			':::image-end:::';
 		const editor = window.activeTextEditor;
 		const actualText = editor?.document.getText();
+		await sleep(longSleepTime);
 		assert.equal(expectedText, actualText);
 		stubShowQuickPick.restore();
 		stubShowInputBox.restore();
@@ -165,7 +170,7 @@ suite('Image Controller', () => {
 		let editor = window.activeTextEditor;
 		common.setCursorPosition(editor!, 0, 4);
 		await pickImageType(context);
-		await sleep(extendedSleepTime);
+		await sleep(longSleepTime);
 		const expectedText =
 			':::image type="content" source="../images/test.png" alt-text="foo" loc-scope="markdown":::' +
 			os.EOL;
@@ -200,7 +205,7 @@ suite('Image Controller', () => {
 			os.EOL;
 		editor = window.activeTextEditor;
 		const actualText = editor?.document.getText();
-		await sleep(extendedSleepTime);
+		await sleep(longSleepTime);
 		assert.equal(expectedText, actualText);
 		stubShowQuickPick.restore();
 	});
@@ -227,12 +232,12 @@ suite('Image Controller', () => {
 		let editor = window.activeTextEditor;
 		common.setCursorPosition(editor!, 0, 4);
 		await pickImageType(context);
-		await sleep(extendedSleepTime);
 		const expectedText =
 			':::image type="content" source="../images/test.png" alt-text="foo" link="https://microsoft.com":::' +
 			os.EOL;
 		editor = window.activeTextEditor;
 		const actualText = editor?.document.getText();
+		await sleep(longSleepTime);
 		assert.equal(expectedText, actualText);
 		stubShowQuickPick.restore();
 		stubAxios.restore();

--- a/packages/docs-markdown/src/test/suite/controllers/image-controller.test.ts
+++ b/packages/docs-markdown/src/test/suite/controllers/image-controller.test.ts
@@ -101,10 +101,10 @@ suite('Image Controller', () => {
 
 		await loadDocumentAndGetItReady(filePath);
 		await pickImageType(context);
-		await sleep(extendedSleepTime);
 		const expectedText = ':::image type="content" source="../images/test.png" alt-text="foo":::';
 		const editor = window.activeTextEditor;
 		const actualText = editor?.document.getText();
+		await sleep(extendedSleepTime);
 		assert.equal(expectedText, actualText);
 		stubShowQuickPick.restore();
 		stubShowInputBox.restore();

--- a/packages/docs-markdown/src/test/suite/controllers/image-controller.test.ts
+++ b/packages/docs-markdown/src/test/suite/controllers/image-controller.test.ts
@@ -195,12 +195,12 @@ suite('Image Controller', () => {
 		let editor = window.activeTextEditor;
 		common.setCursorPosition(editor!, 0, 4);
 		await pickImageType(context);
-		await sleep(extendedSleepTime);
 		const expectedText =
 			':::image type="content" source="../images/test.png" alt-text="foo" loc-scope="markdown" lightbox="../images/test.png":::' +
 			os.EOL;
 		editor = window.activeTextEditor;
 		const actualText = editor?.document.getText();
+		await sleep(extendedSleepTime);
 		assert.equal(expectedText, actualText);
 		stubShowQuickPick.restore();
 	});

--- a/packages/docs-markdown/src/test/suite/controllers/image-controller.test.ts
+++ b/packages/docs-markdown/src/test/suite/controllers/image-controller.test.ts
@@ -32,7 +32,7 @@ import sinon = require('sinon');
 
 const expect = chai.expect;
 
-suite.only('Image Controller', () => {
+suite('Image Controller', () => {
 	// Reset and tear down the spies
 	teardown(() => {
 		chai.spy.restore(common);

--- a/packages/docs-markdown/src/test/suite/controllers/image-controller.test.ts
+++ b/packages/docs-markdown/src/test/suite/controllers/image-controller.test.ts
@@ -32,7 +32,7 @@ import sinon = require('sinon');
 
 const expect = chai.expect;
 
-suite('Image Controller', () => {
+suite.only('Image Controller', () => {
 	// Reset and tear down the spies
 	teardown(() => {
 		chai.spy.restore(common);
@@ -106,10 +106,10 @@ suite('Image Controller', () => {
 
 		await loadDocumentAndGetItReady(filePath);
 		await pickImageType(context);
+		await sleep(longSleepTime);
 		const expectedText = ':::image type="content" source="../images/test.png" alt-text="foo":::';
 		const editor = window.activeTextEditor;
 		const actualText = editor?.document.getText();
-		await sleep(longSleepTime);
 		assert.equal(expectedText, actualText);
 		stubShowQuickPick.restore();
 		stubShowInputBox.restore();
@@ -135,6 +135,7 @@ suite('Image Controller', () => {
 
 		await loadDocumentAndGetItReady(filePath);
 		await pickImageType(context);
+		await sleep(longSleepTime);
 		const expectedText =
 			':::image type="complex" source="../images/test.png" alt-text="foo":::' +
 			os.EOL +
@@ -142,7 +143,6 @@ suite('Image Controller', () => {
 			':::image-end:::';
 		const editor = window.activeTextEditor;
 		const actualText = editor?.document.getText();
-		await sleep(longSleepTime);
 		assert.equal(expectedText, actualText);
 		stubShowQuickPick.restore();
 		stubShowInputBox.restore();
@@ -200,12 +200,12 @@ suite('Image Controller', () => {
 		let editor = window.activeTextEditor;
 		common.setCursorPosition(editor!, 0, 4);
 		await pickImageType(context);
+		await sleep(longSleepTime);
 		const expectedText =
 			':::image type="content" source="../images/test.png" alt-text="foo" loc-scope="markdown" lightbox="../images/test.png":::' +
 			os.EOL;
 		editor = window.activeTextEditor;
 		const actualText = editor?.document.getText();
-		await sleep(longSleepTime);
 		assert.equal(expectedText, actualText);
 		stubShowQuickPick.restore();
 	});
@@ -232,12 +232,12 @@ suite('Image Controller', () => {
 		let editor = window.activeTextEditor;
 		common.setCursorPosition(editor!, 0, 4);
 		await pickImageType(context);
+		await sleep(longSleepTime);
 		const expectedText =
 			':::image type="content" source="../images/test.png" alt-text="foo" link="https://microsoft.com":::' +
 			os.EOL;
 		editor = window.activeTextEditor;
 		const actualText = editor?.document.getText();
-		await sleep(longSleepTime);
 		assert.equal(expectedText, actualText);
 		stubShowQuickPick.restore();
 		stubAxios.restore();


### PR DESCRIPTION
Now supporting content subsets defined in the docfx.json file.
 - Searching if content exists in docfx.json
 - matching both link path, current file path with docfx src. 

[AB#386119](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/386119)