### PR TITLE
docs-markdown production release 0.2.86

### DIFF
--- a/packages/docs-markdown/changelog.md
+++ b/packages/docs-markdown/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.86 (April 15th, 2021)
+
+- Added functionality for formatting markdown table as data matrix using right click context menu when table is selected.
+
 ## 0.2.85 (March 9th, 2021)
 
 - Bug fixes for Add Docs link by URL for content subset in docfx.

--- a/packages/docs-markdown/package.json
+++ b/packages/docs-markdown/package.json
@@ -4,7 +4,7 @@
 	"description": "Docs Markdown Extension",
 	"icon": "images/docs-logo-ms.png",
 	"aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-	"version": "0.2.85",
+	"version": "0.2.86",
 	"publisher": "docsmsft",
 	"homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
 	"bugs": {


### PR DESCRIPTION
## 0.2.86 (April 15th, 2021)

- Added functionality for formatting markdown table as data matrix using right click context menu when table is selected.
