### PR TITLE
Fixed regex for lightbox insert.

### DIFF
--- a/packages/docs-markdown/src/controllers/image-controller.ts
+++ b/packages/docs-markdown/src/controllers/image-controller.ts
@@ -394,7 +394,7 @@ export async function applyLocScope(context: ExtensionContext) {
 		return;
 	}
 	// if user has not selected any text, then continue
-	const RE_LOC_SCOPE = /:::image\s+((source|type|alt-text|lightbox|border|link)="([a-zA-Z0-9_.\/ -]+)"\s*)+:::/gm;
+	const RE_LOC_SCOPE = /:::image\s+((source|type|alt-text|lightbox|border|link)="(.*?)"\s*)+:::/gm;
 	const position = new Position(editor.selection.active.line, editor.selection.active.character);
 	// get the current editor position and check if user is inside :::image::: tags
 	const wordRange = editor.document.getWordRangeAtPosition(position, RE_LOC_SCOPE);
@@ -428,7 +428,7 @@ export async function applyLocScope(context: ExtensionContext) {
 			});
 		}
 	} else {
-		const RE_LOC_SCOPE_EXISTS = /:::image\s+((source|type|alt-text|lightbox|border|loc-scope|link)="([a-zA-Z0-9_.\/ -]+)"\s*)+:::/gm;
+		const RE_LOC_SCOPE_EXISTS = /:::image\s+((source|type|alt-text|lightbox|border|loc-scope|link)="(.*?)"\s*)+:::/gm;
 		const locScopeAlreadyExists = editor.document.getWordRangeAtPosition(
 			position,
 			RE_LOC_SCOPE_EXISTS
@@ -452,7 +452,7 @@ export async function applyLightbox() {
 	}
 
 	// if user has not selected any text, then continue
-	const RE_LIGHTBOX = /:::image\s+((source|type|alt-text|loc-scope|border|link)="([a-zA-Z0-9_.\/ -]+)"\s*)+:::/gm;
+	const RE_LIGHTBOX = /:::image\s+((source|type|alt-text|loc-scope|border|link)="(.*?)"\s*)+:::/gm;
 	const position = new Position(editor.selection.active.line, editor.selection.active.character);
 	// get the current editor position and check if user is inside :::image::: tags
 	const wordRange = editor.document.getWordRangeAtPosition(position, RE_LIGHTBOX);
@@ -496,7 +496,7 @@ export async function applyLightbox() {
 			}
 		});
 	} else {
-		const RE_LIGHTBOX_EXISTS = /:::image\s+((source|type|alt-text|lightbox|border|loc-scope|link)="([a-zA-Z0-9_.\/ -]+)"\s*)+:::/gm;
+		const RE_LIGHTBOX_EXISTS = /:::image\s+((source|type|alt-text|lightbox|border|loc-scope|link)="(.*?)"\s*)+:::/gm;
 		const lightboxAlreadyExists = editor.document.getWordRangeAtPosition(
 			position,
 			RE_LIGHTBOX_EXISTS
@@ -544,7 +544,7 @@ export async function applyLink() {
 	}
 
 	// if user has not selected any text, then continue
-	const RE_LINK = /:::image\s+((source|type|alt-text|lightbox|border|loc-scope)="([a-zA-Z0-9_.\/ -]+)"\s*)+:::/gm;
+	const RE_LINK = /:::image\s+((source|type|alt-text|lightbox|border|loc-scope)="(.*?)"\s*)+:::/gm;
 	const position = new Position(editor.selection.active.line, editor.selection.active.character);
 	// get the current editor position and check if user is inside :::image::: tags
 	const wordRange = editor.document.getWordRangeAtPosition(position, RE_LINK);
@@ -564,7 +564,7 @@ export async function applyLink() {
 			});
 		}
 	} else {
-		const RE_LINK_EXISTS = /:::image\s+((source|type|alt-text|lightbox|border|loc-scope|link)="([a-zA-Z0-9_.\/ -:]+)"\s*)+:::/gm;
+		const RE_LINK_EXISTS = /:::image\s+((source|type|alt-text|lightbox|border|loc-scope|link)="(.*?)"\s*)+:::/gm;
 		const linkAlreadyExists = editor.document.getWordRangeAtPosition(position, RE_LINK_EXISTS);
 		if (linkAlreadyExists) {
 			window.showErrorMessage('link attribute already exists on :::image::: tag.');

--- a/packages/docs-markdown/src/test/data/repo/articles/image-controller6.md
+++ b/packages/docs-markdown/src/test/data/repo/articles/image-controller6.md
@@ -1,1 +1,1 @@
-:::image type="content" source="../images/test.png" alt-text="foo" link="https://microsoft.com":::
+:::image type="content" source="../images/test.png" alt-text="foo":::

--- a/packages/docs-markdown/src/test/suite/controllers/image-controller.test.ts
+++ b/packages/docs-markdown/src/test/suite/controllers/image-controller.test.ts
@@ -218,11 +218,11 @@ suite('Image Controller', () => {
 		const item1: QuickPickItem = {
 			label: 'add link to image'
 		};
-		const item2: QuickPickItem = {
-			label: 'https://microsoft.com'
-		};
+
+		const stubShowInputBox = sinon.stub(window, 'showInputBox');
+		const input: string = 'https://microsoft.com';
 		stubShowQuickPick.onCall(0).resolves(item1);
-		stubShowQuickPick.onCall(1).resolves(item2);
+		stubShowInputBox.onCall(0).resolves(input);
 		const filePath = resolve(
 			__dirname,
 			'../../../../../src/test/data/repo/articles/image-controller6.md'


### PR DESCRIPTION
Addressed issue where if the :::image::: tag had a comman (,) in the alt-text if would not register as an :::image::: tag. This issue has been fixed for this PR on all the inserting functionality like loc-scope, link, and lightbox.

[AB#420613](https://dev.azure.com/ceapex/d3d54af3-265a-4f18-95f6-9a46397ca583/_workitems/edit/420613)