### PR TITLE
Production release of docs-markdown version 0.2.95

### DIFF
--- a/packages/docs-markdown/changelog.md
+++ b/packages/docs-markdown/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.95 (June 10th, 2021)
+
+- Added metadata tree view in metadata explorer panel that displays the markdown metadata from the current .md file and docfx.json.
+
 ## 0.2.94 (June 2nd, 2021)
 
 - Header link generator fix: [Issue 880](https://github.com/microsoft/vscode-docs-authoring/issues/880)

--- a/packages/docs-markdown/package.json
+++ b/packages/docs-markdown/package.json
@@ -4,7 +4,7 @@
 	"description": "Docs Markdown Extension",
 	"icon": "images/docs-logo-ms.png",
 	"aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-	"version": "0.2.94",
+	"version": "0.2.95",
 	"publisher": "docsmsft",
 	"homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",
 	"bugs": {


### PR DESCRIPTION
- Added metadata tree view in metadata explorer panel that displays the markdown metadata from the current .md file and docfx.json