### PR TITLE
Remove unused file-system dependency from docs-metadata

### DIFF
--- a/packages/docs-metadata/package.json
+++ b/packages/docs-metadata/package.json
@@ -113,7 +113,6 @@
 		"@types/mkdirp": "^0.5.2",
 		"@types/tmp": "^0.1.0",
 		"@types/yauzl": "^2.9.1",
-		"file-system": "^2.2.2",
 		"http-proxy-agent": "^2.1.0",
 		"https-proxy-agent": "^2.2.4",
 		"mkdirp": "^0.5.1",

--- a/packages/docs-metadata/src/test/suite/extension.test.ts
+++ b/packages/docs-metadata/src/test/suite/extension.test.ts
@@ -25,6 +25,7 @@ export const context: ExtensionContext = {
 	globalState: {
 		get: key => {},
 		update: (key, value) => Promise.resolve(),
+		keys: () => [],
 		setKeysForSync(keys: string[]): void {}
 	},
 	secrets: {
@@ -36,7 +37,8 @@ export const context: ExtensionContext = {
 	subscriptions,
 	workspaceState: {
 		get: () => {},
-		update: (key, value) => Promise.resolve()
+		update: (key, value) => Promise.resolve(),
+		keys: () => []
 	},
 	extensionPath: '',
 	asAbsolutePath: relative => '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4837,21 +4837,6 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-match@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/file-match/-/file-match-1.0.2.tgz#c9cad265d2c8adf3a81475b0df475859069faef7"
-  integrity sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=
-  dependencies:
-    utils-extend "^1.0.6"
-
-file-system@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/file-system/-/file-system-2.2.2.tgz#7d65833e3a2347dcd956a813c677153ed3edd987"
-  integrity sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=
-  dependencies:
-    file-match "^1.0.1"
-    utils-extend "^1.0.4"
-
 file-type@*:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-16.5.0.tgz#16a2626f3b33bac612f6e81e52216f3a7c8e12a2"
@@ -11982,11 +11967,6 @@ util@^0.11.0:
   integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
-
-utils-extend@^1.0.4, utils-extend@^1.0.6:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/utils-extend/-/utils-extend-1.0.8.tgz#ccfd7b64540f8e90ee21eec57769d0651cab8a5f"
-  integrity sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8=
 
 utils-merge@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Remove unused file-system dependency to fix security issue with utils-extend

![image](https://user-images.githubusercontent.com/11825888/125345357-4c5a5300-e30d-11eb-9e79-5539c6ea844b.png)
