### PR TITLE
Removing docs-visual-areas as it is causing issues

### DIFF
--- a/packages/docs-authoring-pack/package.json
+++ b/packages/docs-authoring-pack/package.json
@@ -3,7 +3,7 @@
   "displayName": "Docs Authoring Pack",
   "description": "Collection of extensions to assist with content development for docs.microsoft.com",
   "icon": "images/docs-logo-ms.png",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "publisher": "docsmsft",
   "private": true,
   "engines": {
@@ -34,8 +34,7 @@
     "docsmsft.docs-yaml",
     "docsmsft.docs-metadata",
     "blackmist.LinkCheckMD",
-    "docsmsft.docs-scaffolding",
-    "docsmsft.docs-visual-areas"
+    "docsmsft.docs-scaffolding"
   ],
   "extensionDependencies": [
     "DavidAnson.vscode-markdownlint",
@@ -49,8 +48,7 @@
     "docsmsft.docs-yaml",
     "docsmsft.docs-metadata",
     "blackmist.LinkCheckMD",
-    "docsmsft.docs-scaffolding",
-    "docsmsft.docs-visual-areas"
+    "docsmsft.docs-scaffolding"
   ],
   "license": "MIT"
 }


### PR DESCRIPTION
- docs-visual-areas is causing slow downs on various user machines. Rolling back to previous version. Unfortunately I believe users will have to uninstall docs-visual-areas for the issues to go away until the problem is resolved with the docs-visual-areas extension.