### PR TITLE
Change docs visual areas to update on save

### DIFF
--- a/packages/docs-visual-areas/src/event-handlers.ts
+++ b/packages/docs-visual-areas/src/event-handlers.ts
@@ -1,39 +1,9 @@
-import * as vscode from 'vscode';
+import { TextDocumentWillSaveEvent, workspace } from 'vscode';
 import { triggerUpdateDecorations } from './decorations';
-import { State } from './models';
-import { updateStatusBarItem } from './statusbar';
 
 export function addEventHandlers() {
-	const { extensionContext: context } = State;
-	let { activeTextEditor } = vscode.window;
-
-	vscode.window.onDidChangeActiveTextEditor(
-		editor => {
-			activeTextEditor = editor;
-			if (editor) {
-				triggerUpdateDecorations();
-				updateStatusBarItem();
-			}
-		},
-		null,
-		context.subscriptions
-	);
-
-	vscode.workspace.onDidChangeTextDocument(
-		event => {
-			if (activeTextEditor && event.document === activeTextEditor.document) {
-				triggerUpdateDecorations();
-			}
-		},
-		null,
-		context.subscriptions
-	);
-
-	vscode.window.onDidChangeTextEditorSelection(
-		event => {
-			updateStatusBarItem();
-		},
-		null,
-		context.subscriptions
-	);
+	workspace.onWillSaveTextDocument(willSaveTextDocument);
+	async function willSaveTextDocument(e: TextDocumentWillSaveEvent) {
+		e.waitUntil(Promise.resolve(triggerUpdateDecorations()));
+	}
 }

--- a/packages/docs-visual-areas/src/extension.ts
+++ b/packages/docs-visual-areas/src/extension.ts
@@ -13,8 +13,6 @@ export function activate(context: vscode.ExtensionContext) {
 	addSubscriptions();
 	addEventHandlers();
 
-	// context.subscriptions.push(disposable);
-
 	if (activeTextEditor) {
 		triggerUpdateDecorations();
 		updateStatusBarItem();


### PR DESCRIPTION
- Fixed issue to stop docs-visual-areas from checking document on change.
- Now looking at document on save.