### PR TITLE
Fix metadata refresh functionality

### DIFF
--- a/packages/docs-markdown/src/controllers/metadata/metadata-controller.ts
+++ b/packages/docs-markdown/src/controllers/metadata/metadata-controller.ts
@@ -39,7 +39,7 @@ export function getAllEffectiveMetadata(docFxFileInfo: DocFxFileInfo): MetadataE
 		const result = results.find(r => !!r.groups && r.groups.metadata);
 		if (result) {
 			try {
-				const metadataJson = jsyaml.load(result.groups.metadata);
+				const metadataJson = jsyaml.load(result.groups.metadata, { skipInvalid: true });
 				if (metadataJson) {
 					const lines = result.groups.metadata.split(/\r\n|\n\r|\n|\r/);
 					for (const [key, value] of Object.entries(metadataJson)) {

--- a/packages/docs-markdown/src/extension.ts
+++ b/packages/docs-markdown/src/extension.ts
@@ -201,7 +201,9 @@ export async function activate(context: ExtensionContext) {
 			}
 		}
 	});
-	workspace.onDidChangeTextDocument(e => {
+
+	// Refresh when the active file is changed, including closing it.
+	window.onDidChangeActiveTextEditor(e => {
 		metadataTreeProvider.refresh();
 	});
 


### PR DESCRIPTION
Metadata Explorer was no longer refreshing automatically either when you opened a different Markdown file or when you closed the active file.

Changing to this event also fixes the error that pops up when you start typing a new metadata key in the YAML front matter.