### PR TITLE
docs-markdown release 0.2.97

### DIFF
--- a/packages/docs-markdown/changelog.md
+++ b/packages/docs-markdown/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.2.97 (August 13th, 2021)
 
-- Small update the metadata tree view in metadata explorer.
+- Small update to the metadata tree view in metadata explorer.
 
 ## 0.2.95 (June 10th, 2021)
 

--- a/packages/docs-markdown/changelog.md
+++ b/packages/docs-markdown/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.97 (August 13th, 2021)
+
+- Small update the metadata tree view in metadata explorer.
+
 ## 0.2.95 (June 10th, 2021)
 
 - Added metadata tree view in metadata explorer panel that displays the markdown metadata from the current .md file and docfx.json.

--- a/packages/docs-markdown/package.json
+++ b/packages/docs-markdown/package.json
@@ -4,7 +4,7 @@
 	"description": "Docs Markdown Extension",
 	"icon": "images/docs-logo-ms.png",
 	"aiKey": "0a0e5961-85c2-451a-bce8-6a54e37c93be",
-	"version": "0.2.96",
+	"version": "0.2.97",
 	"publisher": "docsmsft",
 	"private": true,
 	"homepage": "https://github.com/Microsoft/vscode-docs-authoring/tree/master/docs-markdown",


### PR DESCRIPTION
- Small update the metadata tree view onchange event.