### PR TITLE
Add missing license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 - present Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
According to the [extension listing on the Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-authoring-pack#license), this extension has an MIT license. But the link there is a 404: https://github.com/Microsoft/vscode-docs-authoring/blob/HEAD/LICENSE. This PR adds that missing license file with the [MIT license content available on the Choose a License site](https://choosealicense.com/licenses/mit/#).

## Assumptions

When adding the new license file, a few assumptions were made. Any that are incorrect will require adjustments.

1. Assumes this extension was intending to use the MIT license. If not, the content of the license file can be swapped here, and the extension listing will need updating too.
2. Assumes the copyright start year should be "Copyright (c) 2018 - present". I based the dates on the [date of the earliest commit to the repo](https://github.com/microsoft/vscode-docs-authoring/commit/293bdde59eaa0ab7c821c2b05a9c2b0e385b2520) via `git rev-list --max-parents=0 HEAD`. The "- present" was pulled from what they use on the Visual Studio Code repo](https://github.com/microsoft/vscode/blob/main/LICENSE.txt#L3).
3. Assumes the copyright entity should be identical to what is [used on the Visual Studio Code repo](https://github.com/microsoft/vscode/blob/main/LICENSE.txt#L3): "Microsoft Corporation".

## Possibly related

If I am reading issue #746 correctly, this may allow closing that issue.